### PR TITLE
purego: add go:nosplit to SyscallN

### DIFF
--- a/syscall.go
+++ b/syscall.go
@@ -20,6 +20,8 @@ const maxArgs = 9
 //
 // On amd64, if there are more than 8 floats the 9th and so on will be placed incorrectly on the
 // stack.
+//
+//go:nosplit
 func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 	if len(args) > maxArgs {
 		panic("too many arguments to SyscallN")

--- a/syscall.go
+++ b/syscall.go
@@ -48,6 +48,7 @@ var syscall9XABI0 uintptr
 
 func syscall9X() // implemented in assembly
 
+//go:nosplit
 func syscall_syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr) {
 	args := struct{ fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, r1, r2, err uintptr }{
 		fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, r1, r2, err}


### PR DESCRIPTION
Without go:nosplit, a local variable's address on a stack in a SyscallN
caller might be invalidated unexpectedly.