### PR TITLE
purego: use go:nosplit and map to proper implementation

### DIFF
--- a/syscall.go
+++ b/syscall.go
@@ -1,14 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebiten Authors
 
-//go:build darwin
-// +build darwin
+//go:build darwin || windows
+// +build darwin windows
 
 package purego
 
-import "unsafe"
-
 const maxArgs = 9
+
+// f matches argument numbers to a Syscall implementation that can take that many
+var f = map[int]func(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr){
+	0: syscall_syscallX3,
+	1: syscall_syscallX3,
+	2: syscall_syscallX3,
+	3: syscall_syscallX3,
+	4: syscall_syscallX6,
+	5: syscall_syscallX6,
+	6: syscall_syscallX6,
+	7: syscall_syscall9X,
+	8: syscall_syscall9X,
+	9: syscall_syscall9X,
+}
 
 // SyscallN takes fn, a C function pointer and a list of arguments as uintptr.
 // There is an internal maximum number of arguments that SyscallN can take. It panics
@@ -20,6 +32,7 @@ const maxArgs = 9
 //
 // On amd64, if there are more than 8 floats the 9th and so on will be placed incorrectly on the
 // stack.
+//go:nosplit
 func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 	if len(args) > maxArgs {
 		panic("too many arguments to SyscallN")
@@ -27,28 +40,5 @@ func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 	// add padding so there is no out-of-bounds slicing
 	var tmp [maxArgs]uintptr
 	copy(tmp[:], args)
-	if len(args) <= 6 {
-		// use the 6 argument version because
-		// gl.GenFramebuffersEXT would fail with the 9 version
-		// See https://github.com/hajimehoshi/ebiten/issues/2102#issuecomment-1134679352
-		return syscall_syscall6X(fn, tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5])
-	}
-	return syscall_syscall9X(fn, tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7], tmp[8])
-}
-
-func callc(fn uintptr, args unsafe.Pointer) {
-	runtime_entersyscall()
-	runtime_libcCall(unsafe.Pointer(fn), args)
-	runtime_exitsyscall()
-}
-
-var syscall9XABI0 uintptr
-
-func syscall9X() // implemented in assembly
-
-func syscall_syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr) {
-	args := struct{ fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, r1, r2, err uintptr }{
-		fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, r1, r2, err}
-	callc(syscall9XABI0, unsafe.Pointer(&args))
-	return args.r1, args.r2, args.err
+	return f[len(args)](fn, tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7], tmp[8])
 }

--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -1,0 +1,31 @@
+package purego
+
+import "unsafe"
+
+func callc(fn uintptr, args unsafe.Pointer) {
+	runtime_entersyscall()
+	runtime_libcCall(unsafe.Pointer(fn), args)
+	runtime_exitsyscall()
+}
+
+//go:nosplit
+func syscall_syscallX3(fn, a1, a2, a3, _, _, _, _, _, _ uintptr) (r1, r2, err uintptr) {
+	return syscall_syscall6X(fn, a1, a2, a3, 0, 0, 0)
+}
+
+//go:nosplit
+func syscall_syscallX6(fn, a1, a2, a3, a4, a5, a6, _, _, _ uintptr) (r1, r2, err uintptr) {
+	return syscall_syscall6X(fn, a1, a2, a3, a4, a5, a6)
+}
+
+var syscall9XABI0 uintptr
+
+func syscall9X() // implemented in assembly
+
+//go:nosplit
+func syscall_syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr) {
+	args := struct{ fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, r1, r2, err uintptr }{
+		fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, r1, r2, err}
+	callc(syscall9XABI0, unsafe.Pointer(&args))
+	return args.r1, args.r2, args.err
+}

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -1,0 +1,23 @@
+package purego
+
+import (
+	"syscall"
+)
+
+//go:nosplit
+func syscall_syscallX3(fn, a1, a2, a3, _, _, _, _, _, _ uintptr) (r1, r2, err uintptr) {
+	r1, r2, errno := syscall.Syscall(fn, 3, a1, a2, a3)
+	return r1, r2, uintptr(errno)
+}
+
+//go:nosplit
+func syscall_syscallX6(fn, a1, a2, a3, a4, a5, a6, _, _, _ uintptr) (r1, r2, err uintptr) {
+	r1, r2, errno := syscall.Syscall6(fn, 6, a1, a2, a3, a4, a5, a6)
+	return r1, r2, uintptr(errno)
+}
+
+//go:nosplit
+func syscall_syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr) {
+	r1, r2, errno := syscall.Syscall9(fn, 9, a1, a2, a3, a4, a5, a6, a7, a8, a9)
+	return r1, r2, uintptr(errno)
+}


### PR DESCRIPTION
This uses `go:nosplit` to ensure that the stack does not split as discussed in #5. This commit also adds windows support to purego by calling the syscall.Syscall equivalent function.