### PR TITLE
No red zone

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -10,9 +10,6 @@ import (
 	"unsafe"
 )
 
-//go:linkname syscall_syscall6X syscall.syscall6X
-func syscall_syscall6X(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2, err uintptr) // from runtime/sys_darwin_64.s
-
 //go:linkname runtime_libcCall runtime.libcCall
 //go:linkname runtime_entersyscall runtime.entersyscall
 //go:linkname runtime_exitsyscall runtime.exitsyscall

--- a/sys_darwin_amd64.s
+++ b/sys_darwin_amd64.s
@@ -28,7 +28,7 @@ TEXT ·syscall9X(SB), NOSPLIT, $0
 	PUSHQ BP
 	MOVQ  SP, BP
 	SUBQ  $32, SP
-	MOVQ  DI, -8(BP)     // save the pointer
+	MOVQ  DI, 24(BP)     // save the pointer
 	MOVQ  (0*8)(DI), R10 // fn
 	MOVQ  (2*8)(DI), SI  // a2
 	MOVQ  (3*8)(DI), DX  // a3
@@ -59,7 +59,7 @@ TEXT ·syscall9X(SB), NOSPLIT, $0
 
 	CALL R10
 
-	MOVQ -8(BP), DI     // get the pointer back
+	MOVQ 24(BP), DI     // get the pointer back
 	MOVQ AX, (10*8)(DI) // r1
 	MOVQ DX, (11*8)(DI) // r2
 

--- a/syscall.go
+++ b/syscall.go
@@ -8,20 +8,6 @@ package purego
 
 const maxArgs = 9
 
-// f matches argument numbers to a Syscall implementation that can take that many
-var f = map[int]func(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr){
-	0: syscall_syscallX3,
-	1: syscall_syscallX3,
-	2: syscall_syscallX3,
-	3: syscall_syscallX3,
-	4: syscall_syscallX6,
-	5: syscall_syscallX6,
-	6: syscall_syscallX6,
-	7: syscall_syscall9X,
-	8: syscall_syscall9X,
-	9: syscall_syscall9X,
-}
-
 // SyscallN takes fn, a C function pointer and a list of arguments as uintptr.
 // There is an internal maximum number of arguments that SyscallN can take. It panics
 // when the maximum is exceeded. It returns the result and the libc error code if there is one.
@@ -33,6 +19,7 @@ var f = map[int]func(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, er
 // On amd64, if there are more than 8 floats the 9th and so on will be placed incorrectly on the
 // stack.
 //go:nosplit
+//go:uintptrescapes
 func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 	if len(args) > maxArgs {
 		panic("too many arguments to SyscallN")
@@ -40,5 +27,5 @@ func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 	// add padding so there is no out-of-bounds slicing
 	var tmp [maxArgs]uintptr
 	copy(tmp[:], args)
-	return f[len(args)](fn, tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7], tmp[8])
+	return syscall_syscall9X(fn, tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7], tmp[8])
 }

--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -8,16 +8,6 @@ func callc(fn uintptr, args unsafe.Pointer) {
 	runtime_exitsyscall()
 }
 
-//go:nosplit
-func syscall_syscallX3(fn, a1, a2, a3, _, _, _, _, _, _ uintptr) (r1, r2, err uintptr) {
-	return syscall_syscall6X(fn, a1, a2, a3, 0, 0, 0)
-}
-
-//go:nosplit
-func syscall_syscallX6(fn, a1, a2, a3, a4, a5, a6, _, _, _ uintptr) (r1, r2, err uintptr) {
-	return syscall_syscall6X(fn, a1, a2, a3, a4, a5, a6)
-}
-
 var syscall9XABI0 uintptr
 
 func syscall9X() // implemented in assembly

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -5,18 +5,6 @@ import (
 )
 
 //go:nosplit
-func syscall_syscallX3(fn, a1, a2, a3, _, _, _, _, _, _ uintptr) (r1, r2, err uintptr) {
-	r1, r2, errno := syscall.Syscall(fn, 3, a1, a2, a3)
-	return r1, r2, uintptr(errno)
-}
-
-//go:nosplit
-func syscall_syscallX6(fn, a1, a2, a3, a4, a5, a6, _, _, _ uintptr) (r1, r2, err uintptr) {
-	r1, r2, errno := syscall.Syscall6(fn, 6, a1, a2, a3, a4, a5, a6)
-	return r1, r2, uintptr(errno)
-}
-
-//go:nosplit
 func syscall_syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr) {
 	r1, r2, errno := syscall.Syscall9(fn, 9, a1, a2, a3, a4, a5, a6, a7, a8, a9)
 	return r1, r2, uintptr(errno)


### PR DESCRIPTION
sys_darwin_amd64.s was pushing the struct pointer to -8(SP) which is a part of the red-zone. We have enough space on the stack to push it above the arguments. Doing so is safer too