### PR TITLE
add Ivar support and Objc Tests

### DIFF
--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -7,6 +7,7 @@ package objc
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"runtime"
 	"unsafe"
@@ -159,12 +160,13 @@ func (c Class) AddMethod(name SEL, imp _IMP, types string) bool {
 // It may only be called after AllocateClassPair and before Register.
 // Adding an instance variable to an existing class is not supported.
 // The class must not be a metaclass. Adding an instance variable to a metaclass is not supported.
-// The instance variable's minimum alignment in bytes is 1<<align. The minimum alignment of an
-// instance variable depends on the ivar's type and the machine architecture.
-// For variables of any pointer type, pass math.Log2(unsafe.Alignof(type)).
-func (c Class) AddIvar(name string, size uintptr, alignment uint8, types string) bool {
+// It takes the instance of the type of the Ivar and a string representing the type.
+func (c Class) AddIvar(name string, ty interface{}, types string) bool {
 	n := strings.CString(name)
 	t := strings.CString(types)
+	typeOf := reflect.TypeOf(ty)
+	size := typeOf.Size()
+	alignment := uint8(math.Log2(float64(typeOf.Align())))
 	ret, _, _ := purego.SyscallN(class_addIvar, uintptr(c), uintptr(unsafe.Pointer(n)), size, uintptr(alignment), uintptr(unsafe.Pointer(t)))
 	runtime.KeepAlive(n)
 	runtime.KeepAlive(t)

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -21,15 +21,18 @@ import (
 var (
 	objc = purego.Dlopen("/usr/lib/libobjc.A.dylib", purego.RTLD_GLOBAL)
 
-	objc_msgSend           = purego.Dlsym(objc, "objc_msgSend")
-	objc_msgSendSuper2     = purego.Dlsym(objc, "objc_msgSendSuper2")
-	objc_getClass          = purego.Dlsym(objc, "objc_getClass")
-	objc_allocateClassPair = purego.Dlsym(objc, "objc_allocateClassPair")
-	objc_registerClassPair = purego.Dlsym(objc, "objc_registerClassPair")
-	sel_registerName       = purego.Dlsym(objc, "sel_registerName")
-	class_getSuperclass    = purego.Dlsym(objc, "class_getSuperclass")
-	class_addMethod        = purego.Dlsym(objc, "class_addMethod")
-	object_getClass        = purego.Dlsym(objc, "object_getClass")
+	objc_msgSend              = purego.Dlsym(objc, "objc_msgSend")
+	objc_msgSendSuper2        = purego.Dlsym(objc, "objc_msgSendSuper2")
+	objc_getClass             = purego.Dlsym(objc, "objc_getClass")
+	objc_allocateClassPair    = purego.Dlsym(objc, "objc_allocateClassPair")
+	objc_registerClassPair    = purego.Dlsym(objc, "objc_registerClassPair")
+	sel_registerName          = purego.Dlsym(objc, "sel_registerName")
+	class_getSuperclass       = purego.Dlsym(objc, "class_getSuperclass")
+	class_getInstanceVariable = purego.Dlsym(objc, "class_getInstanceVariable")
+	class_addMethod           = purego.Dlsym(objc, "class_addMethod")
+	class_addIvar             = purego.Dlsym(objc, "class_addIvar")
+	ivar_getOffset            = purego.Dlsym(objc, "ivar_getOffset")
+	object_getClass           = purego.Dlsym(objc, "object_getClass")
 )
 
 // ID is an opaque pointer to some Objective-C object
@@ -152,17 +155,53 @@ func (c Class) AddMethod(name SEL, imp _IMP, types string) bool {
 	return byte(ret) != 0
 }
 
-// Register registers a class that was allocated using objc_allocateClassPair.
+// AddIvar adds a new instance variable to a class.
+// It may only be called after AllocateClassPair and before Register.
+// Adding an instance variable to an existing class is not supported.
+// The class must not be a metaclass. Adding an instance variable to a metaclass is not supported.
+// The instance variable's minimum alignment in bytes is 1<<align. The minimum alignment of an
+// instance variable depends on the ivar's type and the machine architecture.
+// For variables of any pointer type, pass math.Log2(unsafe.Alignof(type)).
+func (c Class) AddIvar(name string, size uintptr, alignment uint8, types string) bool {
+	n := strings.CString(name)
+	t := strings.CString(types)
+	ret, _, _ := purego.SyscallN(class_addIvar, uintptr(c), uintptr(unsafe.Pointer(n)), size, uintptr(alignment), uintptr(unsafe.Pointer(t)))
+	runtime.KeepAlive(n)
+	runtime.KeepAlive(t)
+	return byte(ret) != 0
+}
+
+// InstanceVariable returns an Ivar data structure containing information about the instance variable specified by name.
+func (c Class) InstanceVariable(name string) Ivar {
+	n := strings.CString(name)
+	ret, _, _ := purego.SyscallN(class_getInstanceVariable, uintptr(c), uintptr(unsafe.Pointer(n)))
+	runtime.KeepAlive(n)
+	return Ivar(ret)
+}
+
+// Register registers a class that was allocated using AllocateClassPair.
 // It can now be used to make objects by sending it either alloc and init or new.
 func (c Class) Register() {
 	purego.SyscallN(objc_registerClassPair, uintptr(c))
+}
+
+// Ivar an opaque type that represents an instance variable.
+type Ivar uintptr
+
+// Offset returns the offset of an instance variable that can be used to assign and read the Ivar's value.
+//
+// For instance variables of type id or other object types, call Ivar and SetIvar instead
+// of using this offset to access the instance variable data directly.
+func (i Ivar) Offset() uintptr {
+	ret, _, _ := purego.SyscallN(ivar_getOffset, uintptr(i))
+	return ret
 }
 
 // _IMP is unexported so that the only way to make this type is by providing a Go function and casting
 // it with the IMP function
 type _IMP uintptr
 
-// IMP takes a Go function that takes (id, SEL) as its first two arguments. It returns an _IMP function
+// IMP takes a Go function that takes (ID, SEL) as its first two arguments. It returns an _IMP function
 // pointer that can be called by Objective-C code. The function pointer is never deallocated.
 func IMP(fn interface{}) _IMP {
 	// this is only here so that it is easier to port C code to Go.

--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -27,8 +27,8 @@ func ExampleAllocateClassPair() {
 	}), "v@:\x00")
 	class.Register()
 
-	var FooObject = ID(class).Send(RegisterName("new\x00"))
-	FooObject.Send(RegisterName("run\x00"))
+	var fooObject = ID(class).Send(RegisterName("new\x00"))
+	fooObject.Send(RegisterName("run\x00"))
 	// Output: Hello World!
 }
 
@@ -44,9 +44,9 @@ func ExampleClass_AddIvar() {
 	}), "v@:q\x00")
 	class.Register()
 
-	var BarObject = ID(class).Send(RegisterName("new\x00"))
-	BarObject.Send(RegisterName("setBar:\x00"), 123)
-	var bar = int(BarObject.Send(RegisterName("bar\x00")))
+	var barObject = ID(class).Send(RegisterName("new\x00"))
+	barObject.Send(RegisterName("setBar:\x00"), 123)
+	var bar = int(barObject.Send(RegisterName("bar\x00")))
 	fmt.Println(bar)
 	// Output: 123
 }

--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
+
 package objc
 
 import (

--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -1,0 +1,59 @@
+package objc
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+func init() {
+	// this is here so that the program doesn't crash with:
+	// 		fatal error: schedule: in cgo
+	// this can be removed after purego#12 is solved.
+	// this is due to moving goroutines to different threads while in C code
+	runtime.LockOSThread()
+}
+
+func ExampleAllocateClassPair() {
+	var class = AllocateClassPair(GetClass("NSObject\x00"), "FooObject\x00", 0)
+	class.AddMethod(RegisterName("run\x00"), IMP(func(self ID, _cmd SEL) {
+		fmt.Println("Hello World!")
+	}), "v@:\x00")
+	class.Register()
+
+	var FooObject = ID(class).Send(RegisterName("new\x00"))
+	FooObject.Send(RegisterName("run\x00"))
+	// Output: Hello World!
+}
+
+func ExampleClass_AddIvar() {
+	var class = AllocateClassPair(GetClass("NSObject\x00"), "BarObject\x00", 0)
+	class.AddIvar("bar\x00", unsafe.Sizeof(int(0)), uint8(math.Log2(float64(unsafe.Alignof(int(0))))), "q\x00")
+	var barOffset = class.InstanceVariable("bar\x00").Offset()
+	class.AddMethod(RegisterName("bar\x00"), IMP(func(self ID, _cmd SEL) int {
+		return *(*int)(unsafe.Pointer(uintptr(unsafe.Pointer(self)) + barOffset))
+	}), "q@:\x00")
+	class.AddMethod(RegisterName("setBar:\x00"), IMP(func(self ID, _cmd SEL, bar int) {
+		*(*int)(unsafe.Pointer(uintptr(unsafe.Pointer(self)) + barOffset)) = bar
+	}), "v@:q\x00")
+	class.Register()
+
+	var BarObject = ID(class).Send(RegisterName("new\x00"))
+	BarObject.Send(RegisterName("setBar:\x00"), 123)
+	var bar = int(BarObject.Send(RegisterName("bar\x00")))
+	fmt.Println(bar)
+	// Output: 123
+}
+
+func ExampleIMP() {
+	imp := IMP(func(self ID, _cmd SEL) {
+		fmt.Println("IMP:", self, _cmd)
+	})
+
+	purego.SyscallN(uintptr(imp), 105, 567)
+
+	// Output: IMP: 105 567
+}

--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -5,7 +5,6 @@ package objc
 
 import (
 	"fmt"
-	"math"
 	"runtime"
 	"unsafe"
 
@@ -34,7 +33,7 @@ func ExampleAllocateClassPair() {
 
 func ExampleClass_AddIvar() {
 	var class = AllocateClassPair(GetClass("NSObject\x00"), "BarObject\x00", 0)
-	class.AddIvar("bar\x00", unsafe.Sizeof(int(0)), uint8(math.Log2(float64(unsafe.Alignof(int(0))))), "q\x00")
+	class.AddIvar("bar\x00", int(0), "q\x00")
 	var barOffset = class.InstanceVariable("bar\x00").Offset()
 	class.AddMethod(RegisterName("bar\x00"), IMP(func(self ID, _cmd SEL) int {
 		return *(*int)(unsafe.Pointer(uintptr(unsafe.Pointer(self)) + barOffset))

--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -128,7 +128,7 @@ func callbackWrap(a *callbackArgs) {
 				a.result = 0
 			}
 		default:
-			panic("purego: unsupported kind: %s" + k.String())
+			panic("purego: unsupported kind: " + k.String())
 		}
 	}
 }

--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -116,7 +116,20 @@ func callbackWrap(a *callbackArgs) {
 	}
 	ret := fn.Call(args)
 	if len(ret) > 0 {
-		a.result = uintptr(ret[0].Uint())
+		switch k := ret[0].Kind(); k {
+		case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8, reflect.Uintptr:
+			a.result = uintptr(ret[0].Uint())
+		case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
+			a.result = uintptr(ret[0].Int())
+		case reflect.Bool:
+			if ret[0].Bool() {
+				a.result = 1
+			} else {
+				a.result = 0
+			}
+		default:
+			panic("purego: unsupported kind: %s" + k.String())
+		}
 	}
 }
 


### PR DESCRIPTION
Ivar or InstanceVariables are like fields in a struct except for Objective-C objects. This PR add support for adding Ivars to classes. It also provides an example of how to use them properly.

This will be needed to fully port glfw to Go