### PR TITLE
purego: use a safe way to convert a pointer to a byte slice

### DIFF
--- a/dlfcn.go
+++ b/dlfcn.go
@@ -65,7 +65,12 @@ func Dlerror() string {
 	}
 	// use unsafe.Slice once we reach 1.17
 	s := make([]byte, length)
-	copy(s, *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{Data: msg, Len: length, Cap: length})))
+	var src []byte
+	h := (*reflect.SliceHeader)(unsafe.Pointer(&src))
+	h.Data = msg
+	h.Len = length
+	h.Cap = length
+	copy(s, src)
 	return string(s)
 }
 


### PR DESCRIPTION
Creating a reflect.SliceHeader is invalid. See https://pkg.go.dev/unsafe#Pointer