### PR TITLE
remove go:nosplit at SyscallN

### DIFF
--- a/syscall.go
+++ b/syscall.go
@@ -20,7 +20,8 @@ const maxArgs = 9
 // stack.
 //
 // the pragma go:nosplit is not needed at this function declaration because it uses go:uintptrescapes
-// to push all the uintptr onto the heap where a stack split won't affect their memory location.
+// which forces all the objects that the uintptrs point to onto the heap where a stack split won't affect
+// their memory location.
 //
 //go:uintptrescapes
 func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {

--- a/syscall.go
+++ b/syscall.go
@@ -18,7 +18,10 @@ const maxArgs = 9
 //
 // On amd64, if there are more than 8 floats the 9th and so on will be placed incorrectly on the
 // stack.
-//go:nosplit
+//
+// the pragma go:nosplit is not needed at this function declaration because it uses go:uintptrescapes
+// to push all the uintptr onto the heap where a stack split won't affect their memory location.
+//
 //go:uintptrescapes
 func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 	if fn == 0 {

--- a/syscall.go
+++ b/syscall.go
@@ -19,7 +19,7 @@ const maxArgs = 9
 // On amd64, if there are more than 8 floats the 9th and so on will be placed incorrectly on the
 // stack.
 //
-// the pragma go:nosplit is not needed at this function declaration because it uses go:uintptrescapes
+// The pragma go:nosplit is not needed at this function declaration because it uses go:uintptrescapes
 // which forces all the objects that the uintptrs point to onto the heap where a stack split won't affect
 // their memory location.
 //


### PR DESCRIPTION
this is allowed because SyscallN also uses go:uintptrescapes which forces any uintptr's that are passed to this function to be placed on the heap where a stack split won't affect them. See the [compile docs](https://pkg.go.dev/cmd/compile) for an explanation.

I've tested this change on Oto (amd64 & arm64) without optimizations. I also ran all the test for ebitengine (amd64 & arm64) with OpenGL and Metal.

All this to say, this won't break anything.

This change fixes [Oto#182](https://github.com/hajimehoshi/oto/issues/182).