### PR TITLE
internal/fakecgo: add build tags 'darwin'

### DIFF
--- a/internal/fakecgo/callbacks.go
+++ b/internal/fakecgo/callbacks.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin
+// +build darwin
+
 package fakecgo
 
 import _ "unsafe"

--- a/internal/fakecgo/doc.go
+++ b/internal/fakecgo/doc.go
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
+//go:build darwin
+// +build darwin
+
 // Package fakecgo implements the Cgo runtime (runtime/cgo) entirely in Go.
 // This allows code that calls into C to function properly when CGO_ENABLED=0.
 //

--- a/internal/fakecgo/go_libinit.go
+++ b/internal/fakecgo/go_libinit.go
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
+//go:build darwin
+// +build darwin
+
 package fakecgo
 
 import (

--- a/internal/fakecgo/go_setenv.go
+++ b/internal/fakecgo/go_setenv.go
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
+//go:build darwin
+// +build darwin
+
 package fakecgo
 
 //go:nosplit

--- a/internal/fakecgo/go_util.go
+++ b/internal/fakecgo/go_util.go
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
+//go:build darwin
+// +build darwin
+
 package fakecgo
 
 import "unsafe"

--- a/internal/fakecgo/iscgo.go
+++ b/internal/fakecgo/iscgo.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin
+// +build darwin
+
 // The runtime package contains an uninitialized definition
 // for runtime·iscgo. Override it to tell the runtime we're here.
 // There are various function pointers that should be set too,

--- a/internal/fakecgo/libcgo.go
+++ b/internal/fakecgo/libcgo.go
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
+//go:build darwin
+// +build darwin
+
 package fakecgo
 
 type size_t uintptr

--- a/internal/fakecgo/setenv.go
+++ b/internal/fakecgo/setenv.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin
+// +build darwin
+
 package fakecgo
 
 import _ "unsafe" // for go:linkname

--- a/internal/fakecgo/symbols.go
+++ b/internal/fakecgo/symbols.go
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
+//go:build darwin
+// +build darwin
+
 package fakecgo
 
 import "unsafe"

--- a/internal/fakecgo/trampolines_amd64.s
+++ b/internal/fakecgo/trampolines_amd64.s
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
+//go:build darwin
+// +build darwin
+
 /*
 trampoline for emulating required C functions for cgo in go (see cgo.go)
 (we convert cdecl calling convention to go and vice-versa)

--- a/internal/fakecgo/trampolines_arm64.s
+++ b/internal/fakecgo/trampolines_arm64.s
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
+//go:build darwin
+// +build darwin
+
 #include "textflag.h"
 #include "go_asm.h"
 


### PR DESCRIPTION
This enables to build purego with `./...` for Windows.

Closes #28