### PR TITLE
internal/abi: add a dummy Go file for go mod vendor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
           echo 'package main' > main.go
           echo 'import (' >> main.go
           echo '  _ "github.com/ebitengine/purego"' >> main.go
+          echo '  _ "github.com/ebitengine/purego/cgo"' >> main.go
           echo ')' >> main.go
           echo 'func main() {}' >> main.go
           go mod edit -replace github.com/ebitengine/purego=$GITHUB_WORKSPACE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,6 @@ jobs:
           echo 'package main' > main.go
           echo 'import (' >> main.go
           echo '  _ "github.com/ebitengine/purego"' >> main.go
-          echo '  _ "github.com/ebitengine/purego/cgo"' >> main.go
           echo ')' >> main.go
           echo 'func main() {}' >> main.go
           go mod edit -replace github.com/ebitengine/purego=$GITHUB_WORKSPACE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
           go mod edit -replace github.com/ebitengine/purego=$GITHUB_WORKSPACE
           go mod tidy
           go mod vendor
-          go build ./...
+          go build -v .
 
       - name: go test
         if: ${{ !startsWith(matrix.go, '1.15.') }} # TODO: Remove this condition after #27 is fixed.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           # Check cross-compiling Windows binaries.
           env GOOS=windows GOARCH=arm64 go build -v ./...
 
-      - name; go mod vendor
+      - name: go mod vendor
         run: |
           mkdir /tmp/vendoring
           cd /tmp/vendoring

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,21 @@ jobs:
           # Check cross-compiling Windows binaries.
           env GOOS=windows GOARCH=arm64 go build -v ./...
 
+      - name; go mod vendor
+        run: |
+          mkdir /tmp/vendoring
+          cd /tmp/vendoring
+          go mod init foo
+          echo 'package main' > main.go
+          echo 'import (' >> main.go
+          echo '  _ "github.com/ebitengine/purego"' >> main.go
+          echo ')' >> main.go
+          echo 'func main() {}' >> main.go
+          go mod edit -replace github.com/ebitengine/purego=$GITHUB_WORKSPACE
+          go mod tidy
+          go mod vendor
+          go build ./...
+
       - name: go test
         if: ${{ !startsWith(matrix.go, '1.15.') }} # TODO: Remove this condition after #27 is fixed.
         run: |

--- a/dummy.go
+++ b/dummy.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
+
+//go:build dummy
+// +build dummy
+
+// This file exists purely to prevent the Go toolchain from stripping
+// away the c source directories and files when `go mod vendor` is used
+// to populate a `vendor/` directory of a project depending on this package.
+
+package purego
+
+import (
+	_ "github.com/ebitengine/purego/internal/abi"
+)

--- a/dummy.go
+++ b/dummy.go
@@ -5,7 +5,7 @@
 // +build dummy
 
 // This file exists purely to prevent the Go toolchain from stripping
-// away the c source directories and files when `go mod vendor` is used
+// away the C source directories and files when `go mod vendor` is used
 // to populate a `vendor/` directory of a project depending on this package.
 
 package purego

--- a/internal/abi/dummy.go
+++ b/internal/abi/dummy.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
+
+//go:build dummy
+// +build dummy
+
+// Package abi is a dummy package that prevents go tooling from stripping the C dependencies.
+package abi


### PR DESCRIPTION
Before this change, the package `internal/abi` was ignored by `go mod vendor`
as there was no Go file there. Then building purego failed as `internal/abi`
didn't exist under the `vendor` directory.

This change fixes this issue by adding a dummy Go file to `internal/abi`
and adding an explicit import to it, but with a `dummy` build tag.

I referred a change https://github.com/goccy/go-graphviz/pull/37 for this
hack.

Updates #31