### PR TITLE
purego: make callbacks with more than 6 arguments work properly on amd64

### DIFF
--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -5,6 +5,7 @@ package objc_test
 
 import (
 	"fmt"
+	"log"
 	"unsafe"
 
 	"github.com/ebitengine/purego"
@@ -14,12 +15,14 @@ import (
 func ExampleAllocateClassPair() {
 	var class = objc.AllocateClassPair(objc.GetClass("NSObject"), "FooObject", 0)
 	class.AddMethod(objc.RegisterName("run"), objc.NewIMP(func(self objc.ID, _cmd objc.SEL) {
+		log.Println(self)
 		fmt.Println("Hello World!")
 	}), "v@:")
 	class.Register()
 
 	var fooObject = objc.ID(class).Send(objc.RegisterName("new"))
 	fooObject.Send(objc.RegisterName("run"))
+	log.Println(fooObject)
 	// Output: Hello World!
 }
 
@@ -43,13 +46,13 @@ func ExampleClass_AddIvar() {
 }
 
 func ExampleIMP() {
-	imp := objc.NewIMP(func(self objc.ID, _cmd objc.SEL) {
-		fmt.Println("IMP:", self, _cmd)
+	imp := objc.NewIMP(func(self objc.ID, _cmd objc.SEL, a3, a4, a5, a6, a7, a8, a9 int) {
+		fmt.Println("IMP:", self, _cmd, a3, a4, a5, a6, a7, a8, a9)
 	})
 
-	purego.SyscallN(uintptr(imp), 105, 567)
+	purego.SyscallN(uintptr(imp), 105, 567, 9, 2, 3, ^uintptr(4), 4, 8, 9)
 
-	// Output: IMP: 105 567
+	// Output: IMP: 105 567 9 2 3 -5 4 8 9
 }
 
 func ExampleID_SendSuper() {

--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -5,7 +5,6 @@ package objc_test
 
 import (
 	"fmt"
-	"log"
 	"unsafe"
 
 	"github.com/ebitengine/purego"
@@ -15,14 +14,12 @@ import (
 func ExampleAllocateClassPair() {
 	var class = objc.AllocateClassPair(objc.GetClass("NSObject"), "FooObject", 0)
 	class.AddMethod(objc.RegisterName("run"), objc.NewIMP(func(self objc.ID, _cmd objc.SEL) {
-		log.Println(self)
 		fmt.Println("Hello World!")
 	}), "v@:")
 	class.Register()
 
 	var fooObject = objc.ID(class).Send(objc.RegisterName("new"))
 	fooObject.Send(objc.RegisterName("run"))
-	log.Println(fooObject)
 	// Output: Hello World!
 }
 

--- a/sys_darwin_amd64.s
+++ b/sys_darwin_amd64.s
@@ -89,19 +89,18 @@ TEXT callbackasm1(SB), NOSPLIT, $0
 	ADDQ $8, SP
 
 	MOVQ 0(SP), R12 // get the return SP so that we can align register args with stack args
-	ADDQ $8, SP
 
 	// make space for first six arguments below the frame
 	ADJSP $6*8, SP
-	MOVQ  DI, 0(SP)
-	MOVQ  SI, 8(SP)
-	MOVQ  DX, 16(SP)
-	MOVQ  CX, 24(SP)
-	MOVQ  R8, 32(SP)
-	MOVQ  R9, 40(SP)
-	LEAQ  (SP), R8   // R8 = address of args vector
+	MOVQ  DI, 8(SP)
+	MOVQ  SI, 16(SP)
+	MOVQ  DX, 24(SP)
+	MOVQ  CX, 32(SP)
+	MOVQ  R8, 40(SP)
+	MOVQ  R9, 48(SP)
+	LEAQ  8(SP), R8  // R8 = address of args vector
 
-	PUSHQ R12 // push the stack pointer below registers
+	MOVQ R12, 0(SP) // push the stack pointer below registers
 
 	// determine index into runtime·cbs table
 	MOVQ $callbackasm(SB), DX
@@ -136,11 +135,10 @@ TEXT callbackasm1(SB), NOSPLIT, $0
 
 	POP_REGS_HOST_TO_ABI0()
 
-	POPQ R12 // get the SP back
+	MOVQ 0(SP), R12 // get the SP back
 
 	ADJSP $-6*8, SP // remove arguments
 
-	SUBQ $8, SP     // readjust stack pointer
 	MOVQ R12, 0(SP)
 
 	RET

--- a/sys_darwin_amd64.s
+++ b/sys_darwin_amd64.s
@@ -88,8 +88,10 @@ TEXT callbackasm1(SB), NOSPLIT, $0
 	MOVQ 0(SP), AX
 	ADDQ $8, SP
 
+	MOVQ 0(SP), R12 // get the return SP so that we can align register args with stack args
+	ADDQ $8, SP
+
 	// make space for first six arguments below the frame
-	// TODO: check to make sure that arguments 7 and above are right after these six
 	ADJSP $6*8, SP
 	MOVQ  DI, 0(SP)
 	MOVQ  SI, 8(SP)
@@ -98,6 +100,8 @@ TEXT callbackasm1(SB), NOSPLIT, $0
 	MOVQ  R8, 32(SP)
 	MOVQ  R9, 40(SP)
 	LEAQ  (SP), R8   // R8 = address of args vector
+
+	PUSHQ R12 // push the stack pointer below registers
 
 	// determine index into runtime·cbs table
 	MOVQ $callbackasm(SB), DX
@@ -132,6 +136,11 @@ TEXT callbackasm1(SB), NOSPLIT, $0
 
 	POP_REGS_HOST_TO_ABI0()
 
+	POPQ R12 // get the SP back
+
 	ADJSP $-6*8, SP // remove arguments
+
+	SUBQ $8, SP     // readjust stack pointer
+	MOVQ R12, 0(SP)
 
 	RET

--- a/sys_darwin_arm64.s
+++ b/sys_darwin_arm64.s
@@ -77,7 +77,7 @@ TEXT callbackWrapInternal<>(SB), NOSPLIT, $0-0
 TEXT callbackasm1(SB), NOSPLIT, $208-0
 	NO_LOCAL_POINTERS
 
-	// On entry, the trampoline in zcallback_windows_arm64.s left
+	// On entry, the trampoline in zcallback_darwin_arm64.s left
 	// the callback index in R12 (which is volatile in the C ABI).
 
 	// Save callback register arguments R0-R7.


### PR DESCRIPTION
There was a TODO that I never tested. This PR updates ExampleIMP to test this behavior and fixes amd64 which was broken.