### PR TITLE
.githug/workflows: simplify test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,13 +57,13 @@ jobs:
           env GOOS=windows GOARCH=arm64 go build -v ./...
 
       - name: go build (iOS, Go 1.15)
-        if : ${{ startsWith(matrix.go, '1.15.') && startsWith(matrix.os, 'macos-') && }}
+        if : ${{ startsWith(matrix.go, '1.15.') && startsWith(matrix.os, 'macos-') }}
         run: |
           env CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags=ios ./...
           env CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -v -tags=ios ./...
 
-      - name: go build (iOS, Go 1.16)
-        if : ${{ !startsWith(matrix.go, '1.15.') && startsWith(matrix.os, 'macos-') && }}
+      - name: go build (iOS, Go 1.16 and newer)
+        if : ${{ !startsWith(matrix.go, '1.15.') && startsWith(matrix.os, 'macos-') }}
         run: |
           env CGO_ENABLED=1 GOOS=ios GOARCH=amd64 go build -v ./...
           env CGO_ENABLED=1 GOOS=ios GOARCH=arm64 go build -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,18 +56,6 @@ jobs:
           # Check cross-compiling Windows binaries.
           env GOOS=windows GOARCH=arm64 go build -v ./...
 
-      - name: go build (iOS, Go 1.15)
-        if : ${{ startsWith(matrix.go, '1.15.') && startsWith(matrix.os, 'macos-') }}
-        run: |
-          env CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags=ios ./...
-          env CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -v -tags=ios ./...
-
-      - name: go build (iOS, Go 1.16 and newer)
-        if : ${{ !startsWith(matrix.go, '1.15.') && startsWith(matrix.os, 'macos-') }}
-        run: |
-          env CGO_ENABLED=1 GOOS=ios GOARCH=amd64 go build -v ./...
-          env CGO_ENABLED=1 GOOS=ios GOARCH=arm64 go build -v ./...
-
       - name: go mod vendor
         run: |
           mkdir /tmp/vendoring

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,10 +55,6 @@ jobs:
         run: |
           # Check cross-compiling Windows binaries.
           env GOOS=windows GOARCH=arm64 go build -v ./...
-          
-          # Check cross-compiling macOS binaries.
-          env GOOS=darwin GOARCH=amd64 go build -tags=example -v ./...
-          env GOOS=darwin GOARCH=arm64 go build -tags=example -v ./...
 
       - name: go mod vendor
         run: |
@@ -77,4 +73,4 @@ jobs:
 
       - name: go test
         run: |
-          go test -tags=example ${{ !startsWith(matrix.go, '1.15.') && !startsWith(matrix.go, '1.16.') && '-shuffle=on' || '' }} -v -count=10 ./...
+          go test ${{ !startsWith(matrix.go, '1.15.') && !startsWith(matrix.go, '1.16.') && '-shuffle=on' || '' }} -v -count=10 ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,18 @@ jobs:
           # Check cross-compiling Windows binaries.
           env GOOS=windows GOARCH=arm64 go build -v ./...
 
+      - name: go build (iOS, Go 1.15)
+        if : ${{ startsWith(matrix.go, '1.15.') && startsWith(matrix.os, 'macos-') && }}
+        run: |
+          env CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags=ios ./...
+          env CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -v -tags=ios ./...
+
+      - name: go build (iOS, Go 1.16)
+        if : ${{ !startsWith(matrix.go, '1.15.') && startsWith(matrix.os, 'macos-') && }}
+        run: |
+          env CGO_ENABLED=1 GOOS=ios GOARCH=amd64 go build -v ./...
+          env CGO_ENABLED=1 GOOS=ios GOARCH=arm64 go build -v ./...
+
       - name: go mod vendor
         run: |
           mkdir /tmp/vendoring


### PR DESCRIPTION
* A build tag `example` is not used anywhre.
* Building with GOOO=darwin and GOARCH=arm64 are duplicated.
* Tests for iOS were missing

In the ideal world, we should run the binary with ARM64 for macOS,
in addition to the buildings.