### PR TITLE
objc: add protocol support

### DIFF
--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -232,6 +232,7 @@ type Protocol uintptr
 func GetProtocol(name string) *Protocol {
 	n := strings.CString(name)
 	p, _, _ := purego.SyscallN(objc_getProtocol, uintptr(unsafe.Pointer(n)))
+	runtime.KeepAlive(n)
 	return *(**Protocol)(unsafe.Pointer(&p))
 }
 

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -233,6 +233,7 @@ func GetProtocol(name string) *Protocol {
 	n := strings.CString(name)
 	p, _, _ := purego.SyscallN(objc_getProtocol, uintptr(unsafe.Pointer(n)))
 	runtime.KeepAlive(n)
+	// We take the address and then dereference it to trick go vet from creating a possible miss-use of unsafe.Pointer
 	return *(**Protocol)(unsafe.Pointer(&p))
 }
 

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -25,6 +25,7 @@ var (
 	objc_msgSend              = purego.Dlsym(objc, "objc_msgSend")
 	objc_msgSendSuper2        = purego.Dlsym(objc, "objc_msgSendSuper2")
 	objc_getClass             = purego.Dlsym(objc, "objc_getClass")
+	objc_getProtocol          = purego.Dlsym(objc, "objc_getProtocol")
 	objc_allocateClassPair    = purego.Dlsym(objc, "objc_allocateClassPair")
 	objc_registerClassPair    = purego.Dlsym(objc, "objc_registerClassPair")
 	sel_registerName          = purego.Dlsym(objc, "sel_registerName")
@@ -32,6 +33,7 @@ var (
 	class_getInstanceVariable = purego.Dlsym(objc, "class_getInstanceVariable")
 	class_addMethod           = purego.Dlsym(objc, "class_addMethod")
 	class_addIvar             = purego.Dlsym(objc, "class_addIvar")
+	class_addProtocol         = purego.Dlsym(objc, "class_addProtocol")
 	ivar_getOffset            = purego.Dlsym(objc, "ivar_getOffset")
 	object_getClass           = purego.Dlsym(objc, "object_getClass")
 )
@@ -189,6 +191,14 @@ func (c Class) AddIvar(name string, ty interface{}, types string) bool {
 	return byte(ret) != 0
 }
 
+// AddProtocol adds a protocol to a class.
+// Returns true if the protocol was added successfully, otherwise NO (for example,
+// the class already conforms to that protocol).
+func (c Class) AddProtocol(protocol Protocol) bool {
+	ret, _, _ := purego.SyscallN(class_addProtocol, uintptr(c), uintptr(protocol))
+	return byte(ret) != 0
+}
+
 // InstanceVariable returns an Ivar data structure containing information about the instance variable specified by name.
 func (c Class) InstanceVariable(name string) Ivar {
 	n := strings.CString(name)
@@ -213,6 +223,16 @@ type Ivar uintptr
 func (i Ivar) Offset() uintptr {
 	ret, _, _ := purego.SyscallN(ivar_getOffset, uintptr(i))
 	return ret
+}
+
+// Protocol is a type that declares methods that can be implemented by any class.
+type Protocol uintptr
+
+// GetProtocol returns the protocol for the given name or nil if there is no protocol by that name.
+func GetProtocol(name string) Protocol {
+	n := strings.CString(name)
+	p, _, _ := purego.SyscallN(objc_getProtocol, uintptr(unsafe.Pointer(n)))
+	return Protocol(p)
 }
 
 // IMP is a function pointer that can be called by Objective-C code.

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -192,7 +192,7 @@ func (c Class) AddIvar(name string, ty interface{}, types string) bool {
 }
 
 // AddProtocol adds a protocol to a class.
-// Returns true if the protocol was added successfully, otherwise NO (for example,
+// Returns true if the protocol was added successfully, otherwise false (for example,
 // the class already conforms to that protocol).
 func (c Class) AddProtocol(protocol Protocol) bool {
 	ret, _, _ := purego.SyscallN(class_addProtocol, uintptr(c), uintptr(protocol))

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -194,8 +194,8 @@ func (c Class) AddIvar(name string, ty interface{}, types string) bool {
 // AddProtocol adds a protocol to a class.
 // Returns true if the protocol was added successfully, otherwise false (for example,
 // the class already conforms to that protocol).
-func (c Class) AddProtocol(protocol Protocol) bool {
-	ret, _, _ := purego.SyscallN(class_addProtocol, uintptr(c), uintptr(protocol))
+func (c Class) AddProtocol(protocol *Protocol) bool {
+	ret, _, _ := purego.SyscallN(class_addProtocol, uintptr(c), uintptr(unsafe.Pointer(protocol)))
 	return byte(ret) != 0
 }
 
@@ -229,10 +229,10 @@ func (i Ivar) Offset() uintptr {
 type Protocol uintptr
 
 // GetProtocol returns the protocol for the given name or nil if there is no protocol by that name.
-func GetProtocol(name string) Protocol {
+func GetProtocol(name string) *Protocol {
 	n := strings.CString(name)
 	p, _, _ := purego.SyscallN(objc_getProtocol, uintptr(unsafe.Pointer(n)))
-	return Protocol(p)
+	return *(**Protocol)(unsafe.Pointer(&p))
 }
 
 // IMP is a function pointer that can be called by Objective-C code.


### PR DESCRIPTION
This is needed for [ebitengien#2326](https://github.com/hajimehoshi/ebiten/pull/2326).

Should the `GetProtocol` function return a pointer to Protocol or just Protocol? The Objective-C [runtime](https://developer.apple.com/documentation/objectivec/1418870-objc_getprotocol?language=objc) returns a pointer however there is never a reason for us to need to dereference this pointer so I thought it best to just remove it.