### PR TITLE
Simplify assembly

### DIFF
--- a/dlfcn.go
+++ b/dlfcn.go
@@ -84,7 +84,22 @@ func Dlclose(handle uintptr) bool {
 }
 
 // these functions exist in dlfcn_stubs.s and are calling C functions linked to in dlfcn_GOOS.go
-var dlopenABI0 uintptr
-var dlsymABI0 uintptr
-var dlcloseABI0 uintptr
-var dlerrorABI0 uintptr
+// the indirection is necessary because a function is actually a pointer to the pointer to the code.
+// sadly, I do not know of anyway to remove the assembly stubs entirely because //go:linkname doesn't
+// appear to work if you link directly to the C function on darwin arm64.
+
+//go:linkname dlopen dlopen
+var dlopen uintptr
+var dlopenABI0 = uintptr(unsafe.Pointer(&dlopen))
+
+//go:linkname dlsym dlsym
+var dlsym uintptr
+var dlsymABI0 = uintptr(unsafe.Pointer(&dlsym))
+
+//go:linkname dlclose dlclose
+var dlclose uintptr
+var dlcloseABI0 = uintptr(unsafe.Pointer(&dlclose))
+
+//go:linkname dlerror dlerror
+var dlerror uintptr
+var dlerrorABI0 = uintptr(unsafe.Pointer(&dlerror))

--- a/dlfcn_stubs.s
+++ b/dlfcn_stubs.s
@@ -7,29 +7,21 @@
 #include "textflag.h"
 
 // func dlopen(path *byte, mode int) (ret uintptr)
-GLOBL ·dlopenABI0(SB), NOPTR|RODATA, $8
-DATA ·dlopenABI0(SB)/8, $dlopen(SB)
 TEXT dlopen(SB), NOSPLIT, $0-0
 	JMP _dlopen(SB)
 	RET
 
 // func dlsym(handle uintptr, symbol *byte) (ret uintptr)
-GLOBL ·dlsymABI0(SB), NOPTR|RODATA, $8
-DATA ·dlsymABI0(SB)/8, $dlsym(SB)
 TEXT dlsym(SB), NOSPLIT, $0-0
 	JMP _dlsym(SB)
 	RET
 
 // func dlerror() (ret *byte)
-GLOBL ·dlerrorABI0(SB), NOPTR|RODATA, $8
-DATA ·dlerrorABI0(SB)/8, $dlerror(SB)
 TEXT dlerror(SB), NOSPLIT, $0-0
 	JMP _dlerror(SB)
 	RET
 
 // func dlclose(handle uintptr) (ret int)
-GLOBL ·dlcloseABI0(SB), NOPTR|RODATA, $8
-DATA ·dlcloseABI0(SB)/8, $dlclose(SB)
 TEXT dlclose(SB), NOSPLIT, $0-0
 	JMP _dlclose(SB)
 	RET

--- a/internal/fakecgo/symbols.go
+++ b/internal/fakecgo/symbols.go
@@ -17,108 +17,108 @@ func memmove(to, from unsafe.Pointer, n uintptr)
 // call5 takes fn the C function and 5 arguments and calls the function with those arguments
 func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
 
-//go:linkname _malloc _malloc
-var _malloc uintptr
-var mallocABI0 = uintptr(unsafe.Pointer(&_malloc))
-
 func malloc(size uintptr) unsafe.Pointer {
 	ret := call5(mallocABI0, size, 0, 0, 0, 0)
 	// this indirection is to avoid go vet complaining about possible misuse of unsafe.Pointer
 	return *(*unsafe.Pointer)(unsafe.Pointer(&ret))
 }
 
-//go:linkname _free _free
-var _free uintptr
-var freeABI0 = uintptr(unsafe.Pointer(&_free))
-
 func free(ptr unsafe.Pointer) {
 	call5(freeABI0, uintptr(ptr), 0, 0, 0, 0)
 }
-
-//go:linkname _setenv _setenv
-var _setenv uintptr
-var setenvABI0 = uintptr(unsafe.Pointer(&_setenv))
 
 func setenv(name *byte, value *byte, overwrite int32) int32 {
 	return int32(call5(setenvABI0, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), uintptr(overwrite), 0, 0))
 }
 
-//go:linkname _unsetenv _unsetenv
-var _unsetenv uintptr
-var unsetenvABI0 = uintptr(unsafe.Pointer(&_unsetenv))
-
 func unsetenv(name *byte) int32 {
 	return int32(call5(unsetenvABI0, uintptr(unsafe.Pointer(name)), 0, 0, 0, 0))
 }
-
-//go:linkname _pthread_attr_init _pthread_attr_init
-var _pthread_attr_init uintptr
-var pthread_attr_initABI0 = uintptr(unsafe.Pointer(&_pthread_attr_init))
 
 func pthread_attr_init(attr *pthread_attr_t) int32 {
 	return int32(call5(pthread_attr_initABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
 }
 
-//go:linkname _pthread_create _pthread_create
-var _pthread_create uintptr
-var pthread_createABI0 = uintptr(unsafe.Pointer(&_pthread_create))
-
 func pthread_create(thread *pthread_t, attr *pthread_attr_t, start, arg unsafe.Pointer) int32 {
 	return int32(call5(pthread_createABI0, uintptr(unsafe.Pointer(thread)), uintptr(unsafe.Pointer(attr)), uintptr(start), uintptr(arg), 0))
 }
-
-//go:linkname _pthread_detach _pthread_detach
-var _pthread_detach uintptr
-var pthread_detachABI0 = uintptr(unsafe.Pointer(&_pthread_detach))
 
 func pthread_detach(thread pthread_t) int32 {
 	return int32(call5(pthread_detachABI0, uintptr(thread), 0, 0, 0, 0))
 }
 
-//go:linkname _pthread_sigmask _pthread_sigmask
-var _pthread_sigmask uintptr
-var pthread_sigmaskABI0 = uintptr(unsafe.Pointer(&_pthread_sigmask))
-
 func pthread_sigmask(how sighow, ign *sigset_t, oset *sigset_t) int32 {
 	return int32(call5(pthread_sigmaskABI0, uintptr(how), uintptr(unsafe.Pointer(ign)), uintptr(unsafe.Pointer(oset)), 0, 0))
 }
-
-//go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
-var _pthread_attr_getstacksize uintptr
-var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
 
 func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32 {
 	return int32(call5(pthread_attr_getstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(unsafe.Pointer(stacksize)), 0, 0, 0))
 }
 
-//go:linkname _pthread_attr_destroy _pthread_attr_destroy
-var _pthread_attr_destroy uintptr
-var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
-
 func pthread_attr_destroy(attr *pthread_attr_t) int32 {
 	return int32(call5(pthread_attr_destroyABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
 }
-
-//go:linkname _sigfillset _sigfillset
-var _sigfillset uintptr
-var sigfillsetABI0 = uintptr(unsafe.Pointer(&_sigfillset))
 
 func sigfillset(set *sigset_t) int32 {
 	return int32(call5(sigfillsetABI0, uintptr(unsafe.Pointer(set)), 0, 0, 0, 0))
 }
 
-//go:linkname _nanosleep _nanosleep
-var _nanosleep uintptr
-var nanosleepABI0 = uintptr(unsafe.Pointer(&_nanosleep))
-
 func nanosleep(ts *timespec, rem *timespec) int32 {
 	return int32(call5(nanosleepABI0, uintptr(unsafe.Pointer(ts)), uintptr(unsafe.Pointer(rem)), 0, 0, 0))
 }
 
-//go:linkname _abort _abort
-var _abort uintptr
-var abortABI0 = uintptr(unsafe.Pointer(&_abort))
-
 func abort() {
 	call5(abortABI0, 0, 0, 0, 0, 0)
 }
+
+//go:linkname _malloc _malloc
+var _malloc uintptr
+var mallocABI0 = uintptr(unsafe.Pointer(&_malloc))
+
+//go:linkname _free _free
+var _free uintptr
+var freeABI0 = uintptr(unsafe.Pointer(&_free))
+
+//go:linkname _setenv _setenv
+var _setenv uintptr
+var setenvABI0 = uintptr(unsafe.Pointer(&_setenv))
+
+//go:linkname _unsetenv _unsetenv
+var _unsetenv uintptr
+var unsetenvABI0 = uintptr(unsafe.Pointer(&_unsetenv))
+
+//go:linkname _pthread_attr_init _pthread_attr_init
+var _pthread_attr_init uintptr
+var pthread_attr_initABI0 = uintptr(unsafe.Pointer(&_pthread_attr_init))
+
+//go:linkname _pthread_create _pthread_create
+var _pthread_create uintptr
+var pthread_createABI0 = uintptr(unsafe.Pointer(&_pthread_create))
+
+//go:linkname _pthread_detach _pthread_detach
+var _pthread_detach uintptr
+var pthread_detachABI0 = uintptr(unsafe.Pointer(&_pthread_detach))
+
+//go:linkname _pthread_sigmask _pthread_sigmask
+var _pthread_sigmask uintptr
+var pthread_sigmaskABI0 = uintptr(unsafe.Pointer(&_pthread_sigmask))
+
+//go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
+var _pthread_attr_getstacksize uintptr
+var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
+
+//go:linkname _pthread_attr_destroy _pthread_attr_destroy
+var _pthread_attr_destroy uintptr
+var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
+
+//go:linkname _sigfillset _sigfillset
+var _sigfillset uintptr
+var sigfillsetABI0 = uintptr(unsafe.Pointer(&_sigfillset))
+
+//go:linkname _nanosleep _nanosleep
+var _nanosleep uintptr
+var nanosleepABI0 = uintptr(unsafe.Pointer(&_nanosleep))
+
+//go:linkname _abort _abort
+var _abort uintptr
+var abortABI0 = uintptr(unsafe.Pointer(&_abort))

--- a/internal/fakecgo/symbols.go
+++ b/internal/fakecgo/symbols.go
@@ -8,44 +8,117 @@ package fakecgo
 
 import "unsafe"
 
+// setg_trampoline calls setg with the G provided
 func setg_trampoline(setg uintptr, G uintptr)
 
 //go:linkname memmove runtime.memmove
 func memmove(to, from unsafe.Pointer, n uintptr)
 
-func malloc(size uintptr) unsafe.Pointer
+// call5 takes fn the C function and 5 arguments and calls the function with those arguments
+func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
 
-func free(ptr unsafe.Pointer)
+//go:linkname _malloc _malloc
+var _malloc uintptr
+var mallocABI0 = uintptr(unsafe.Pointer(&_malloc))
 
-func setenv(name *byte, value *byte, overwrite int32) int32
+func malloc(size uintptr) unsafe.Pointer {
+	ret := call5(mallocABI0, size, 0, 0, 0, 0)
+	// this indirection is to avoid go vet complaining about possible misuse of unsafe.Pointer
+	return *(*unsafe.Pointer)(unsafe.Pointer(&ret))
+}
 
-func unsetenv(name *byte) int32
+//go:linkname _free _free
+var _free uintptr
+var freeABI0 = uintptr(unsafe.Pointer(&_free))
 
-// the no escape comments are needed inorder to ensure Go doesn't try
-// and create a new object in the runtime when the runtime isn't available.
-// After all, we are pretending to be C code.
+func free(ptr unsafe.Pointer) {
+	call5(freeABI0, uintptr(ptr), 0, 0, 0, 0)
+}
 
-//go:noescape
-func pthread_attr_init(attr *pthread_attr_t) int32
+//go:linkname _setenv _setenv
+var _setenv uintptr
+var setenvABI0 = uintptr(unsafe.Pointer(&_setenv))
 
-//go:noescape
-func pthread_create(thread *pthread_t, attr *pthread_attr_t, start, arg unsafe.Pointer) int32
+func setenv(name *byte, value *byte, overwrite int32) int32 {
+	return int32(call5(setenvABI0, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), uintptr(overwrite), 0, 0))
+}
 
-func pthread_detach(thread pthread_t) int32
+//go:linkname _unsetenv _unsetenv
+var _unsetenv uintptr
+var unsetenvABI0 = uintptr(unsafe.Pointer(&_unsetenv))
 
-//go:noescape
-func pthread_sigmask(how sighow, ign *sigset_t, oset *sigset_t) int32
+func unsetenv(name *byte) int32 {
+	return int32(call5(unsetenvABI0, uintptr(unsafe.Pointer(name)), 0, 0, 0, 0))
+}
 
-//go:noescape
-func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32
+//go:linkname _pthread_attr_init _pthread_attr_init
+var _pthread_attr_init uintptr
+var pthread_attr_initABI0 = uintptr(unsafe.Pointer(&_pthread_attr_init))
 
-//go:noescape
-func pthread_attr_destroy(attr *pthread_attr_t) int32
+func pthread_attr_init(attr *pthread_attr_t) int32 {
+	return int32(call5(pthread_attr_initABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
+}
 
-func abort()
+//go:linkname _pthread_create _pthread_create
+var _pthread_create uintptr
+var pthread_createABI0 = uintptr(unsafe.Pointer(&_pthread_create))
 
-//go:noescape
-func sigfillset(set *sigset_t) int32
+func pthread_create(thread *pthread_t, attr *pthread_attr_t, start, arg unsafe.Pointer) int32 {
+	return int32(call5(pthread_createABI0, uintptr(unsafe.Pointer(thread)), uintptr(unsafe.Pointer(attr)), uintptr(start), uintptr(arg), 0))
+}
 
-//go:noescape
-func nanosleep(ts *timespec, rem *timespec) int32
+//go:linkname _pthread_detach _pthread_detach
+var _pthread_detach uintptr
+var pthread_detachABI0 = uintptr(unsafe.Pointer(&_pthread_detach))
+
+func pthread_detach(thread pthread_t) int32 {
+	return int32(call5(pthread_detachABI0, uintptr(thread), 0, 0, 0, 0))
+}
+
+//go:linkname _pthread_sigmask _pthread_sigmask
+var _pthread_sigmask uintptr
+var pthread_sigmaskABI0 = uintptr(unsafe.Pointer(&_pthread_sigmask))
+
+func pthread_sigmask(how sighow, ign *sigset_t, oset *sigset_t) int32 {
+	return int32(call5(pthread_sigmaskABI0, uintptr(how), uintptr(unsafe.Pointer(ign)), uintptr(unsafe.Pointer(oset)), 0, 0))
+}
+
+//go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
+var _pthread_attr_getstacksize uintptr
+var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
+
+func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32 {
+	return int32(call5(pthread_attr_getstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(unsafe.Pointer(stacksize)), 0, 0, 0))
+}
+
+//go:linkname _pthread_attr_destroy _pthread_attr_destroy
+var _pthread_attr_destroy uintptr
+var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
+
+func pthread_attr_destroy(attr *pthread_attr_t) int32 {
+	return int32(call5(pthread_attr_destroyABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
+}
+
+//go:linkname _sigfillset _sigfillset
+var _sigfillset uintptr
+var sigfillsetABI0 = uintptr(unsafe.Pointer(&_sigfillset))
+
+func sigfillset(set *sigset_t) int32 {
+	return int32(call5(sigfillsetABI0, uintptr(unsafe.Pointer(set)), 0, 0, 0, 0))
+}
+
+//go:linkname _nanosleep _nanosleep
+var _nanosleep uintptr
+var nanosleepABI0 = uintptr(unsafe.Pointer(&_nanosleep))
+
+func nanosleep(ts *timespec, rem *timespec) int32 {
+	return int32(call5(nanosleepABI0, uintptr(unsafe.Pointer(ts)), uintptr(unsafe.Pointer(rem)), 0, 0, 0))
+}
+
+//go:linkname _abort _abort
+var _abort uintptr
+var abortABI0 = uintptr(unsafe.Pointer(&_abort))
+
+func abort() {
+	call5(abortABI0, 0, 0, 0, 0, 0)
+}

--- a/internal/fakecgo/trampolines_amd64.s
+++ b/internal/fakecgo/trampolines_amd64.s
@@ -68,86 +68,13 @@ TEXT threadentry_trampoline(SB), NOSPLIT, $16
 	MOVQ 8(SP), AX
 	RET
 
-TEXT ·setenv(SB), NOSPLIT, $0-0
-	MOVQ name+0(FP), DI
-	MOVQ value+8(FP), SI
-	MOVL overwrite+16(FP), DX
-	CALL libc_setenv(SB)
-	MOVL AX, ret+24(FP)
-	RET
-
-TEXT ·unsetenv(SB), NOSPLIT, $0-0
-	MOVQ name+0(FP), DI
-	CALL libc_unsetenv(SB)
-	MOVL AX, ret+8(FP)
-	RET
-
-TEXT ·malloc(SB), NOSPLIT, $0-0
-	MOVQ size+0(FP), DI
-	CALL libc_malloc(SB)
-	MOVQ AX, ret+8(FP)
-	RET
-
-TEXT ·free(SB), NOSPLIT, $0-0
-	MOVQ ptr+0(FP), DI
-	CALL libc_free(SB)
-	RET
-
-TEXT ·pthread_attr_init(SB), NOSPLIT, $0-12
-	MOVQ attr+0(FP), DI
-	CALL libc_pthread_attr_init(SB)
-	MOVL AX, ret+8(FP)
-	RET
-
-TEXT ·pthread_detach(SB), NOSPLIT, $0-12
-	MOVQ thread+0(FP), DI
-	CALL libc_pthread_detach(SB)
-	MOVL AX, ret+8(FP)
-	RET
-
-TEXT ·pthread_create(SB), NOSPLIT, $0-36
-	MOVQ thread+0(FP), DI
-	MOVQ attr+8(FP), SI
-	MOVQ start+16(FP), DX
-	MOVQ arg+24(FP), CX
-	CALL libc_pthread_create(SB)
-	MOVL AX, ret+32(FP)
-	RET
-
-TEXT ·pthread_attr_destroy(SB), NOSPLIT, $0-0
-	MOVQ attr+0(FP), DI
-	CALL libc_pthread_attr_destroy(SB)
-	MOVL AX, ret+8(FP)
-	RET
-
-TEXT ·pthread_attr_getstacksize(SB), NOSPLIT, $0-0
-	MOVQ attr+0(FP), DI
-	MOVQ stacksize+8(FP), SI
-	CALL libc_pthread_attr_getstacksize(SB)
-	MOVL AX, ret+16(FP)
-	RET
-
-TEXT ·pthread_sigmask(SB), NOSPLIT, $0-0
-	MOVL how+0(FP), DI
-	MOVQ ign+8(FP), SI
-	MOVQ oset+16(FP), DX
-	CALL libc_pthread_sigmask(SB)
-	MOVL AX, ret+24(FP)
-	RET
-
-TEXT ·abort(SB), NOSPLIT, $0-0
-	CALL libc_abort(SB)
-	RET
-
-TEXT ·sigfillset(SB), NOSPLIT, $0-12
-	MOVQ set+0(FP), DI
-	CALL libc_sigfillset(SB)
-	MOVL AX, ret+8(FP)
-	RET
-
-TEXT ·nanosleep(SB), NOSPLIT, $0-20
-	MOVQ ts+0(FP), DI
-	MOVQ rem+8(FP), SI
-	CALL libc_nanosleep(SB)
-	MOVL AX, ret+16(FP)
+TEXT ·call5(SB), NOSPLIT, $0-0
+	MOVQ fn+0(FP), AX
+	MOVQ a1+8(FP), DI
+	MOVQ a2+16(FP), SI
+	MOVQ a3+24(FP), DX
+	MOVQ a4+32(FP), CX
+	MOVQ a5+40(FP), R8
+	CALL AX
+	MOVQ AX, ret+48(FP)
 	RET

--- a/internal/fakecgo/trampolines_arm64.s
+++ b/internal/fakecgo/trampolines_arm64.s
@@ -48,86 +48,13 @@ TEXT threadentry_trampoline(SB), NOSPLIT, $0-0
 	MOVD $0, R0           // TODO: get the return value from threadentry
 	RET
 
-TEXT ·setenv(SB), NOSPLIT, $0-0
-	MOVD name+0(FP), R0
-	MOVD value+8(FP), R1
-	MOVD overwrite+16(FP), R2
-	CALL libc_setenv(SB)
-	MOVD R0, ret+24(FP)
-	RET
-
-TEXT ·unsetenv(SB), NOSPLIT, $0-0
-	MOVD name+0(FP), R0
-	CALL libc_unsetenv(SB)
-	MOVD R0, ret+8(FP)
-	RET
-
-TEXT ·malloc(SB), NOSPLIT, $0-0
-	MOVD size+0(FP), R0
-	CALL libc_malloc(SB)
-	MOVD R0, ret+8(FP)
-	RET
-
-TEXT ·free(SB), NOSPLIT, $0-0
-	MOVD ptr+0(FP), R0
-	CALL libc_free(SB)
-	RET
-
-TEXT ·pthread_attr_init(SB), NOSPLIT, $0-12
-	MOVD attr+0(FP), R0
-	CALL libc_pthread_attr_init(SB)
-	MOVD R0, ret+8(FP)
-	RET
-
-TEXT ·pthread_detach(SB), NOSPLIT, $0-12
-	MOVD thread+0(FP), R0
-	CALL libc_pthread_detach(SB)
-	MOVD R0, ret+8(FP)
-	RET
-
-TEXT ·pthread_create(SB), NOSPLIT, $0-36
-	MOVD thread+0(FP), R0
-	MOVD attr+8(FP), R1
-	MOVD start+16(FP), R2
-	MOVD arg+24(FP), R3
-	CALL libc_pthread_create(SB)
-	MOVD R0, ret+32(FP)
-	RET
-
-TEXT ·pthread_attr_destroy(SB), NOSPLIT, $0-0
-	MOVD attr+0(FP), R0
-	CALL libc_pthread_attr_destroy(SB)
-	MOVD R0, ret+8(FP)
-	RET
-
-TEXT ·pthread_attr_getstacksize(SB), NOSPLIT, $0-0
-	MOVD attr+0(FP), R0
-	MOVD stacksize+8(FP), R1
-	CALL libc_pthread_attr_getstacksize(SB)
-	MOVD R0, ret+16(FP)
-	RET
-
-TEXT ·pthread_sigmask(SB), NOSPLIT, $0-0
-	MOVD how+0(FP), R0
-	MOVD ign+8(FP), R1
-	MOVD oset+16(FP), R2
-	CALL libc_pthread_sigmask(SB)
-	MOVD R0, ret+24(FP)
-	RET
-
-TEXT ·abort(SB), NOSPLIT, $0-0
-	CALL libc_abort(SB)
-	RET
-
-TEXT ·sigfillset(SB), NOSPLIT, $0-12
-	MOVD set+0(FP), R0
-	CALL libc_sigfillset(SB)
-	MOVD R0, ret+8(FP)
-	RET
-
-TEXT ·nanosleep(SB), NOSPLIT, $0-20
-	MOVD ts+0(FP), R0
-	MOVD rem+8(FP), R1
-	CALL libc_nanosleep(SB)
-	MOVD R0, ret+16(FP)
+TEXT ·call5(SB), NOSPLIT, $0-0
+	MOVD fn+0(FP), R6
+	MOVD a1+8(FP), R0
+	MOVD a2+16(FP), R1
+	MOVD a3+24(FP), R2
+	MOVD a4+32(FP), R3
+	MOVD a5+40(FP), R4
+	CALL R6
+	MOVD R0, ret+48(FP)
 	RET

--- a/internal/fakecgo/trampolines_stubs.s
+++ b/internal/fakecgo/trampolines_stubs.s
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
+
+//go:build darwin
+// +build darwin
+
+#include "textflag.h"
+
+// these stubs are here because it is not possible to go:linkname directly the C functions on darwin arm64
+
+TEXT _malloc(SB), NOSPLIT, $0-0
+	JMP libc_malloc(SB)
+	RET
+
+TEXT _free(SB), NOSPLIT, $0-0
+	JMP libc_free(SB)
+	RET
+
+TEXT _setenv(SB), NOSPLIT, $0-0
+	JMP libc_setenv(SB)
+	RET
+
+TEXT _unsetenv(SB), NOSPLIT, $0-0
+	JMP libc_unsetenv(SB)
+	RET
+
+TEXT _pthread_attr_init(SB), NOSPLIT, $0-0
+	JMP libc_pthread_attr_init(SB)
+	RET
+
+TEXT _pthread_create(SB), NOSPLIT, $0-0
+	JMP libc_pthread_create(SB)
+	RET
+
+TEXT _pthread_detach(SB), NOSPLIT, $0-12
+	JMP libc_pthread_detach(SB)
+	RET
+
+TEXT _pthread_sigmask(SB), NOSPLIT, $0-0
+	JMP libc_pthread_sigmask(SB)
+	RET
+
+TEXT _pthread_attr_getstacksize(SB), NOSPLIT, $0-0
+	JMP libc_pthread_attr_getstacksize(SB)
+	RET
+
+TEXT _pthread_attr_destroy(SB), NOSPLIT, $0-0
+	JMP libc_pthread_attr_destroy(SB)
+	RET
+
+TEXT _abort(SB), NOSPLIT, $0-0
+	JMP libc_abort(SB)
+	RET
+
+TEXT _nanosleep(SB), NOSPLIT, $0-0
+	JMP libc_nanosleep(SB)
+	RET
+
+TEXT _sigfillset(SB), NOSPLIT, $0-12
+	CALL libc_sigfillset(SB)
+	RET

--- a/internal/fakecgo/trampolines_stubs_darwin.s
+++ b/internal/fakecgo/trampolines_stubs_darwin.s
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build darwin
-// +build darwin
-
 #include "textflag.h"
 
 // these stubs are here because it is not possible to go:linkname directly the C functions on darwin arm64


### PR DESCRIPTION
Using go:linkname and a call5 trampoline function it is possible to remove assembly and push it into Go code. Arguably, it is pretty ugly Go code but functional. Having less assembly means less chance to make a copy paste error and make it easier to port to other architectures