### PR TITLE
purego: set R2 to be the float return value

### DIFF
--- a/sys_darwin_amd64.s
+++ b/sys_darwin_amd64.s
@@ -64,7 +64,7 @@ TEXT syscall9X(SB), NOSPLIT, $0
 
 	MOVQ 24(BP), DI              // get the pointer back
 	MOVQ AX, syscall9Args_r1(DI) // r1
-	MOVQ DX, syscall9Args_r2(DI) // r2
+	MOVQ X0, syscall9Args_r2(DI) // r2
 
 	XORL AX, AX  // no error (it's ignored anyway)
 	ADDQ $32, SP

--- a/sys_darwin_arm64.s
+++ b/sys_darwin_arm64.s
@@ -57,10 +57,10 @@ TEXT syscall9X(SB), NOSPLIT, $0
 
 	BL (R12)
 
-	MOVD 8(RSP), R2              // pop structure pointer
-	ADD  $16, RSP
-	MOVD R0, syscall9Args_r1(R2) // save r1
-	MOVD R1, syscall9Args_r2(R2) // save r2
+	MOVD  8(RSP), R2              // pop structure pointer
+	ADD   $16, RSP
+	MOVD  R0, syscall9Args_r1(R2) // save r1
+	FMOVD F0, syscall9Args_r2(R2) // save r2
 	RET
 
 // runtime·cgocallback expects a call to the ABIInternal function

--- a/syscall.go
+++ b/syscall.go
@@ -10,7 +10,8 @@ const maxArgs = 9
 
 // SyscallN takes fn, a C function pointer and a list of arguments as uintptr.
 // There is an internal maximum number of arguments that SyscallN can take. It panics
-// when the maximum is exceeded. It returns the result and the libc error code if there is one.
+// when the maximum is exceeded. It returns the integer result in r1 and the float result
+// in r2 and the libc error code if there is one.
 //
 // NOTE: SyscallN does not properly call functions that have both integer and float parameters.
 // See discussion comment https://github.com/ebiten/purego/pull/1#issuecomment-1128057607


### PR DESCRIPTION
SyscallN returns 2 uintptr. Currently, the 2nd return value gets what is in the second integer register which isn't very helpful. This PR puts the first float return value into R2. This is used while porting GLFW to Go