### PR TITLE
Move constants under platform specific file

### DIFF
--- a/dlfcn.go
+++ b/dlfcn.go
@@ -10,10 +10,6 @@ import (
 	"unsafe"
 )
 
-const RTLD_GLOBAL = 0x8
-
-const RTLD_DEFAULT = ^uintptr(1)
-
 var (
 	fnDlopen  func(path string, mode int) uintptr
 	fnDlsym   func(handle uintptr, name string) uintptr

--- a/dlfcn_darwin.go
+++ b/dlfcn_darwin.go
@@ -5,7 +5,7 @@ package purego
 
 // Source for constants: https://opensource.apple.com/source/dyld/dyld-360.14/include/dlfcn.h.auto.html
 
-/* The MODE argument to `dlopen' contains one of the following: */
+// The MODE argument to `dlopen' contains one of the following:
 const (
 	RTLD_LAZY   = 0x1 // Relocations are performed at an implementation-dependent time.
 	RTLD_NOW    = 0x2 // Relocations are performed when the object is loaded.

--- a/dlfcn_darwin.go
+++ b/dlfcn_darwin.go
@@ -13,16 +13,6 @@ const (
 	RTLD_GLOBAL = 0x8 // All symbols are available for relocation processing of other modules.
 )
 
-/*
- * Special handle arguments for dlsym().
- */
-const (
-	RTLD_NEXT      = uintptr(0x8000000000000001) /* Search subsequent objects. */
-	RTLD_DEFAULT   = uintptr(0x8000000000000002) /* Use default search algorithm. */
-	RTLD_SELF      = uintptr(0x8000000000000003) /* Search this and subsequent objects (Mac OS X 10.5 and later) */
-	RTLD_MAIN_ONLY = uintptr(0x8000000000000005) /* Search main executable only (Mac OS X 10.5 and later) */
-)
-
 //go:cgo_import_dynamic purego_dlopen dlopen "/usr/lib/libSystem.B.dylib"
 //go:cgo_import_dynamic purego_dlsym dlsym "/usr/lib/libSystem.B.dylib"
 //go:cgo_import_dynamic purego_dlerror dlerror "/usr/lib/libSystem.B.dylib"

--- a/dlfcn_darwin.go
+++ b/dlfcn_darwin.go
@@ -5,7 +5,6 @@ package purego
 
 // Source for constants: https://opensource.apple.com/source/dyld/dyld-360.14/include/dlfcn.h.auto.html
 
-// The MODE argument to `dlopen' contains one of the following:
 const (
 	RTLD_LAZY   = 0x1 // Relocations are performed at an implementation-dependent time.
 	RTLD_NOW    = 0x2 // Relocations are performed when the object is loaded.

--- a/dlfcn_darwin.go
+++ b/dlfcn_darwin.go
@@ -3,6 +3,26 @@
 
 package purego
 
+// Source for constants: https://opensource.apple.com/source/dyld/dyld-360.14/include/dlfcn.h.auto.html
+
+/* The MODE argument to `dlopen' contains one of the following: */
+const (
+	RTLD_LAZY   = 0x1 // Relocations are performed at an implementation-dependent time.
+	RTLD_NOW    = 0x2 // Relocations are performed when the object is loaded.
+	RTLD_LOCAL  = 0x4 // All symbols are not made available for relocation processing by other modules.
+	RTLD_GLOBAL = 0x8 // All symbols are available for relocation processing of other modules.
+)
+
+/*
+ * Special handle arguments for dlsym().
+ */
+const (
+	RTLD_NEXT      = uintptr(0x8000000000000001) /* Search subsequent objects. */
+	RTLD_DEFAULT   = uintptr(0x8000000000000002) /* Use default search algorithm. */
+	RTLD_SELF      = uintptr(0x8000000000000003) /* Search this and subsequent objects (Mac OS X 10.5 and later) */
+	RTLD_MAIN_ONLY = uintptr(0x8000000000000005) /* Search main executable only (Mac OS X 10.5 and later) */
+)
+
 //go:cgo_import_dynamic purego_dlopen dlopen "/usr/lib/libSystem.B.dylib"
 //go:cgo_import_dynamic purego_dlsym dlsym "/usr/lib/libSystem.B.dylib"
 //go:cgo_import_dynamic purego_dlerror dlerror "/usr/lib/libSystem.B.dylib"


### PR DESCRIPTION
This PR does three things.

1. moves the constants under dlfcn_darwin.go since the value is platform specific
2. remove RTLD_DEFAULT which is specific to darwin.
3. adds RTLD_LAZY, RTLD_NOW, RTLD_LOCAL to complete the unix specification

Closes #52 