### PR TITLE
all: fix build tags

### DIFF
--- a/cgo_darwin.go
+++ b/cgo_darwin.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build cgo
-// +build cgo
 
 package purego
 

--- a/dlfcn.go
+++ b/dlfcn.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin
-// +build darwin
 
 package purego
 

--- a/dummy.go
+++ b/dummy.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build dummy
-// +build dummy
 
 // This file exists purely to prevent the Go toolchain from stripping
 // away the C source directories and files when `go mod vendor` is used

--- a/example/main.go
+++ b/example/main.go
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build darwin || windows
-// +build darwin windows
+//go:build windows
 
 package main
 

--- a/example/main.go
+++ b/example/main.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build windows
+//go:build darwin || windows
 
 package main
 

--- a/go_runtime.go
+++ b/go_runtime.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin
-// +build darwin
 
 package purego
 

--- a/internal/abi/dummy.go
+++ b/internal/abi/dummy.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build dummy
-// +build dummy
 
 // Package abi is a dummy package that prevents go tooling from stripping the C dependencies.
 package abi

--- a/internal/fakecgo/callbacks.go
+++ b/internal/fakecgo/callbacks.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin
-// +build darwin
 
 package fakecgo
 

--- a/internal/fakecgo/doc.go
+++ b/internal/fakecgo/doc.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin
-// +build darwin
 
 // Package fakecgo implements the Cgo runtime (runtime/cgo) entirely in Go.
 // This allows code that calls into C to function properly when CGO_ENABLED=0.

--- a/internal/fakecgo/go_libinit.go
+++ b/internal/fakecgo/go_libinit.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin
-// +build darwin
 
 package fakecgo
 

--- a/internal/fakecgo/go_setenv.go
+++ b/internal/fakecgo/go_setenv.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin
-// +build darwin
 
 package fakecgo
 

--- a/internal/fakecgo/go_util.go
+++ b/internal/fakecgo/go_util.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin
-// +build darwin
 
 package fakecgo
 

--- a/internal/fakecgo/iscgo.go
+++ b/internal/fakecgo/iscgo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin
-// +build darwin
 
 // The runtime package contains an uninitialized definition
 // for runtime·iscgo. Override it to tell the runtime we're here.

--- a/internal/fakecgo/libcgo.go
+++ b/internal/fakecgo/libcgo.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin
-// +build darwin
 
 package fakecgo
 

--- a/internal/fakecgo/setenv.go
+++ b/internal/fakecgo/setenv.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin
-// +build darwin
 
 package fakecgo
 

--- a/internal/fakecgo/symbols.go
+++ b/internal/fakecgo/symbols.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin
-// +build darwin
 
 package fakecgo
 

--- a/is_ios.go
+++ b/is_ios.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build !cgo
-// +build !cgo
 
 package purego
 

--- a/nocgo_darwin.go
+++ b/nocgo_darwin.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build !cgo
-// +build !cgo
 
 package purego
 

--- a/syscall.go
+++ b/syscall.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin || windows
-// +build darwin windows
 
 package purego
 


### PR DESCRIPTION
This change drops old build tag comments `// +build`.
