### PR TITLE
objc: remove unsafe usage from test

### DIFF
--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -180,7 +180,11 @@ func NewIMP(fn interface{}) IMP {
 	switch {
 	case ty.NumIn() < 2:
 		fallthrough
-	case ty.In(0).Kind() != reflect.Uintptr:
+	case ty.In(0).Kind() != reflect.Uintptr && // checks if it's objc.Class
+		// checks if it's a pointer to a struct
+		(ty.In(0).Kind() != reflect.Pointer || ty.In(0).Elem().Kind() != reflect.Struct ||
+			// and that the structs structure matches that of objc.Class
+			ty.In(0).Elem().Field(0).Type != reflect.TypeOf(Class(0))):
 		fallthrough
 	case ty.In(1).Kind() != reflect.Uintptr:
 		panic("objc: NewIMP must take a (id, SEL) as its first two arguments")

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -170,7 +170,8 @@ type IMP uintptr
 
 // NewIMP takes a Go function that takes (ID, SEL) as its first two arguments.
 // ID may instead be a pointer to a struct whose first field has type Class.
-// It returns an IMP function pointer that can be called by Objective-C code. The function pointer is never deallocated.
+// It returns an IMP function pointer that can be called by Objective-C code.
+// The function pointer is never deallocated.
 func NewIMP(fn interface{}) IMP {
 	ty := reflect.TypeOf(fn)
 	if ty.Kind() != reflect.Func {
@@ -184,7 +185,7 @@ func NewIMP(fn interface{}) IMP {
 	case ty.In(0).Kind() != reflect.Uintptr && // checks if it's objc.ID
 		// or that it's a pointer to a struct
 		(ty.In(0).Kind() != reflect.Pointer || ty.In(0).Elem().Kind() != reflect.Struct ||
-			// and that the structs structure matches that of objc.Class
+			// and that the structs first field is an objc.Class
 			ty.In(0).Elem().Field(0).Type != reflect.TypeOf(Class(0))):
 		fallthrough
 	case ty.In(1).Kind() != reflect.Uintptr:

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -168,8 +168,9 @@ func GetProtocol(name string) *Protocol {
 // IMP is a function pointer that can be called by Objective-C code.
 type IMP uintptr
 
-// NewIMP takes a Go function that takes (ID, SEL) as its first two arguments. It returns an IMP function
-// pointer that can be called by Objective-C code. The function pointer is never deallocated.
+// NewIMP takes a Go function that takes (ID, SEL) as its first two arguments.
+// ID may instead be a pointer to a struct whose first field has type Class.
+// It returns an IMP function pointer that can be called by Objective-C code. The function pointer is never deallocated.
 func NewIMP(fn interface{}) IMP {
 	ty := reflect.TypeOf(fn)
 	if ty.Kind() != reflect.Func {
@@ -180,8 +181,8 @@ func NewIMP(fn interface{}) IMP {
 	switch {
 	case ty.NumIn() < 2:
 		fallthrough
-	case ty.In(0).Kind() != reflect.Uintptr && // checks if it's objc.Class
-		// checks if it's a pointer to a struct
+	case ty.In(0).Kind() != reflect.Uintptr && // checks if it's objc.ID
+		// or that it's a pointer to a struct
 		(ty.In(0).Kind() != reflect.Pointer || ty.In(0).Elem().Kind() != reflect.Struct ||
 			// and that the structs structure matches that of objc.Class
 			ty.In(0).Elem().Field(0).Type != reflect.TypeOf(Class(0))):

--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -5,6 +5,7 @@ package objc_test
 
 import (
 	"fmt"
+
 	"github.com/ebitengine/purego"
 	"github.com/ebitengine/purego/objc"
 )

--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -5,7 +5,6 @@ package objc_test
 
 import (
 	"fmt"
-	"unsafe"
 
 	"github.com/ebitengine/purego"
 	"github.com/ebitengine/purego/objc"
@@ -24,20 +23,23 @@ func ExampleAllocateClassPair() {
 }
 
 func ExampleClass_AddIvar() {
+	type barObject struct {
+		isa objc.Class
+		bar int
+	}
 	var class = objc.AllocateClassPair(objc.GetClass("NSObject"), "BarObject", 0)
 	class.AddIvar("bar", int(0), "q")
-	var barOffset = class.InstanceVariable("bar").Offset()
-	class.AddMethod(objc.RegisterName("bar"), objc.NewIMP(func(self objc.ID, _cmd objc.SEL) int {
-		return *(*int)(unsafe.Pointer(uintptr(unsafe.Pointer(self)) + barOffset))
+	class.AddMethod(objc.RegisterName("bar"), objc.NewIMP(func(self *barObject, _cmd objc.SEL) int {
+		return self.bar
 	}), "q@:")
-	class.AddMethod(objc.RegisterName("setBar:"), objc.NewIMP(func(self objc.ID, _cmd objc.SEL, bar int) {
-		*(*int)(unsafe.Pointer(uintptr(unsafe.Pointer(self)) + barOffset)) = bar
+	class.AddMethod(objc.RegisterName("setBar:"), objc.NewIMP(func(self *barObject, _cmd objc.SEL, bar int) {
+		self.bar = bar
 	}), "v@:q")
 	class.Register()
 
-	var barObject = objc.ID(class).Send(objc.RegisterName("new"))
-	barObject.Send(objc.RegisterName("setBar:"), 123)
-	var bar = int(barObject.Send(objc.RegisterName("bar")))
+	var object = objc.ID(class).Send(objc.RegisterName("new"))
+	object.Send(objc.RegisterName("setBar:"), 123)
+	var bar = int(object.Send(objc.RegisterName("bar")))
 	fmt.Println(bar)
 	// Output: 123
 }

--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -5,7 +5,6 @@ package objc_test
 
 import (
 	"fmt"
-
 	"github.com/ebitengine/purego"
 	"github.com/ebitengine/purego/objc"
 )


### PR DESCRIPTION
This PR is based on my comment in #54. It removes all uses of package unsafe from the tests by creating a struct that matches the structure of the Objective-C object.