### PR TITLE
purego: enumerate types that can be returned from callbacks

### DIFF
--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -78,8 +78,7 @@ func compileCallback(fn interface{}) uintptr {
 output:
 	switch {
 	case ty.NumOut() == 1:
-		out := ty.Out(0)
-		switch out.Kind() {
+		switch ty.Out(0).Kind() {
 		case reflect.Pointer, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
 			reflect.Bool, reflect.UnsafePointer:

--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -75,7 +75,18 @@ func compileCallback(fn interface{}) uintptr {
 			panic("purego: unsupported argument type: " + in.Kind().String())
 		}
 	}
-	if ty.NumOut() > 1 || ty.NumOut() == 1 && ty.Out(0).Size() != ptrSize {
+output:
+	switch {
+	case ty.NumOut() == 1:
+		out := ty.Out(0)
+		switch out.Kind() {
+		case reflect.Pointer, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+			reflect.Bool, reflect.UnsafePointer:
+			break output
+		}
+		fallthrough
+	case ty.NumOut() > 1:
 		panic("purego: callbacks can only have one pointer-sized return")
 	}
 	cbs.lock.Lock()

--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -84,9 +84,9 @@ output:
 			reflect.Bool, reflect.UnsafePointer:
 			break output
 		}
-		fallthrough
+		panic("purego: unsupported return type: " + ty.String())
 	case ty.NumOut() > 1:
-		panic("purego: callbacks can only have one pointer-sized return")
+		panic("purego: callbacks can only have one return")
 	}
 	cbs.lock.Lock()
 	defer cbs.lock.Unlock()

--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -132,6 +132,10 @@ func callbackWrap(a *callbackArgs) {
 			} else {
 				a.result = 0
 			}
+		case reflect.Pointer:
+			a.result = ret[0].Pointer()
+		case reflect.UnsafePointer:
+			a.result = ret[0].Pointer()
 		default:
 			panic("purego: unsupported kind: " + k.String())
 		}


### PR DESCRIPTION
This PR explicitly enumerates which types can be returned from a callback. It also adds support for returning `reflect.Pointer` and `reflect.UnsafePointer`