### PR TITLE
internal/fakecgo: refactor

### DIFF
--- a/dlfcn_stubs.s
+++ b/dlfcn_stubs.s
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin
-// +build darwin
 
 #include "textflag.h"
 

--- a/internal/fakecgo/go_libinit.go
+++ b/internal/fakecgo/go_libinit.go
@@ -20,9 +20,12 @@ func x_cgo_notify_runtime_init_done() {
 //
 //go:nosplit
 func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe.Pointer, arg *ThreadStart) int {
-	var tries int
+	var ts syscall.Timespec
+	// tries needs to be the same type as syscall.Timespec.Nsec
+	// but the fields are int32 on 32bit and int64 on 64bit
+	// we assign tries to whatever type syscall.Timespec.Nsec is
+	var tries = ts.Nsec
 	var err int
-	var ts timespec
 
 	for tries = 0; tries < 20; tries++ {
 		err = int(pthread_create(thread, attr, pfn, unsafe.Pointer(arg)))
@@ -33,8 +36,8 @@ func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe
 		if err != int(syscall.EAGAIN) {
 			return err
 		}
-		ts.tv_sec = 0
-		ts.tv_nsec = (tries + 1) * 1000 * 1000 // Milliseconds.
+		ts.Sec = 0
+		ts.Nsec = (tries + 1) * 1000 * 1000 // Milliseconds.
 		nanosleep(&ts, nil)
 	}
 	return int(syscall.EAGAIN)

--- a/internal/fakecgo/go_libinit.go
+++ b/internal/fakecgo/go_libinit.go
@@ -23,7 +23,7 @@ func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe
 	var ts syscall.Timespec
 	// tries needs to be the same type as syscall.Timespec.Nsec
 	// but the fields are int32 on 32bit and int64 on 64bit.
-	// We assign tries to whatever type syscall.Timespec.Nsec is.
+	// tries is assigned to syscall.Timespec.Nsec in order to match its type.
 	var tries = ts.Nsec
 	var err int
 

--- a/internal/fakecgo/go_libinit.go
+++ b/internal/fakecgo/go_libinit.go
@@ -23,7 +23,7 @@ func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe
 	var ts syscall.Timespec
 	// tries needs to be the same type as syscall.Timespec.Nsec
 	// but the fields are int32 on 32bit and int64 on 64bit.
-	// we assign tries to whatever type syscall.Timespec.Nsec is
+	// We assign tries to whatever type syscall.Timespec.Nsec is.
 	var tries = ts.Nsec
 	var err int
 

--- a/internal/fakecgo/go_libinit.go
+++ b/internal/fakecgo/go_libinit.go
@@ -22,7 +22,7 @@ func x_cgo_notify_runtime_init_done() {
 func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe.Pointer, arg *ThreadStart) int {
 	var ts syscall.Timespec
 	// tries needs to be the same type as syscall.Timespec.Nsec
-	// but the fields are int32 on 32bit and int64 on 64bit
+	// but the fields are int32 on 32bit and int64 on 64bit.
 	// we assign tries to whatever type syscall.Timespec.Nsec is
 	var tries = ts.Nsec
 	var err int

--- a/internal/fakecgo/libcgo.go
+++ b/internal/fakecgo/libcgo.go
@@ -6,16 +6,9 @@
 package fakecgo
 
 type size_t uintptr
-
 type sigset_t [128]byte      // TODO: figure out how big this should be
 type pthread_attr_t [56]byte // TODO: figure out how big this should be
 type pthread_t int
-
-// We could take timespec from syscall - but there it uses int32 and int64 for 32 bit and 64 bit arch, which complicates stuff for us
-type timespec struct {
-	tv_sec  int
-	tv_nsec int
-}
 
 // for pthread_sigmask:
 

--- a/internal/fakecgo/symbols.go
+++ b/internal/fakecgo/symbols.go
@@ -5,7 +5,10 @@
 
 package fakecgo
 
-import "unsafe"
+import (
+	"syscall"
+	"unsafe"
+)
 
 // setg_trampoline calls setg with the G provided
 func setg_trampoline(setg uintptr, G uintptr)
@@ -62,7 +65,7 @@ func sigfillset(set *sigset_t) int32 {
 	return int32(call5(sigfillsetABI0, uintptr(unsafe.Pointer(set)), 0, 0, 0, 0))
 }
 
-func nanosleep(ts *timespec, rem *timespec) int32 {
+func nanosleep(ts, rem *syscall.Timespec) int32 {
 	return int32(call5(nanosleepABI0, uintptr(unsafe.Pointer(ts)), uintptr(unsafe.Pointer(rem)), 0, 0, 0))
 }
 

--- a/internal/fakecgo/symbols.go
+++ b/internal/fakecgo/symbols.go
@@ -29,7 +29,7 @@ func free(ptr unsafe.Pointer) {
 	call5(freeABI0, uintptr(ptr), 0, 0, 0, 0)
 }
 
-func setenv(name *byte, value *byte, overwrite int32) int32 {
+func setenv(name, value *byte, overwrite int32) int32 {
 	return int32(call5(setenvABI0, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), uintptr(overwrite), 0, 0))
 }
 
@@ -49,7 +49,7 @@ func pthread_detach(thread pthread_t) int32 {
 	return int32(call5(pthread_detachABI0, uintptr(thread), 0, 0, 0, 0))
 }
 
-func pthread_sigmask(how sighow, ign *sigset_t, oset *sigset_t) int32 {
+func pthread_sigmask(how sighow, ign, oset *sigset_t) int32 {
 	return int32(call5(pthread_sigmaskABI0, uintptr(how), uintptr(unsafe.Pointer(ign)), uintptr(unsafe.Pointer(oset)), 0, 0))
 }
 

--- a/internal/fakecgo/trampolines_amd64.s
+++ b/internal/fakecgo/trampolines_amd64.s
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin
-// +build darwin
 
 /*
 trampoline for emulating required C functions for cgo in go (see cgo.go)

--- a/internal/fakecgo/trampolines_amd64.s
+++ b/internal/fakecgo/trampolines_amd64.s
@@ -29,7 +29,6 @@ return value will be in AX
 
 // these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
 
-// TODO: put <> to make these private
 TEXT x_cgo_init_trampoline(SB), NOSPLIT, $16
 	MOVQ DI, 0(SP)
 	MOVQ SI, 8(SP)

--- a/internal/fakecgo/trampolines_arm64.s
+++ b/internal/fakecgo/trampolines_arm64.s
@@ -9,7 +9,6 @@
 
 // these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
 
-// TODO: put <> to make these private
 TEXT x_cgo_init_trampoline(SB), NOSPLIT, $0-0
 	MOVD R0, 8(RSP)
 	MOVD R1, 16(RSP)

--- a/internal/fakecgo/trampolines_arm64.s
+++ b/internal/fakecgo/trampolines_arm64.s
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
 //go:build darwin
-// +build darwin
 
 #include "textflag.h"
 #include "go_asm.h"


### PR DESCRIPTION
Carrots make the symbol only available in that source file. We need these functions available outside in order for us to call them.

Use the syscall version of Timespec. That way we can clean up our code and not have duplicated types.