### PR TITLE
purego: SyscallN r2 return float

### DIFF
--- a/func_darwin.go
+++ b/func_darwin.go
@@ -136,6 +136,8 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 		case reflect.String:
 			v.SetString(strings.GoString(r1))
 		case reflect.Float32, reflect.Float64:
+			// NOTE: r2 is only the floating return value on 64bit platforms.
+			// On 32bit platforms r2 is the upper part of a 64bit return.
 			v.SetFloat(math.Float64frombits(uint64(r2)))
 		default:
 			panic("purego: unsupported return kind: " + outType.Kind().String())

--- a/func_darwin.go
+++ b/func_darwin.go
@@ -4,6 +4,7 @@
 package purego
 
 import (
+	"math"
 	"reflect"
 	"runtime"
 	"unsafe"
@@ -110,7 +111,7 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 				panic("purego: unsupported kind: " + v.Kind().String())
 			}
 		}
-		r1, _, _ := SyscallN(cfn, sysargs...) //TODO: handle float32/64 and struct types
+		r1, r2, _ := SyscallN(cfn, sysargs...) //TODO: handle float32/64 and struct types
 		if ty.NumOut() == 0 {
 			return nil
 		}
@@ -134,6 +135,8 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 			RegisterFunc(v.Interface(), r1)
 		case reflect.String:
 			v.SetString(strings.GoString(r1))
+		case reflect.Float32, reflect.Float64:
+			v.SetFloat(math.Float64frombits(uint64(r2)))
 		default:
 			panic("purego: unsupported return kind: " + outType.Kind().String())
 		}

--- a/sys_darwin_amd64.s
+++ b/sys_darwin_amd64.s
@@ -64,7 +64,7 @@ TEXT syscall9X(SB), NOSPLIT, $0
 
 	MOVQ 24(BP), DI              // get the pointer back
 	MOVQ AX, syscall9Args_r1(DI) // r1
-	MOVQ DX, syscall9Args_r2(DI) // r2
+	MOVQ X0, syscall9Args_r2(DI) // r2
 
 	XORL AX, AX  // no error (it's ignored anyway)
 	ADDQ $32, SP

--- a/sys_darwin_arm64.s
+++ b/sys_darwin_arm64.s
@@ -57,10 +57,10 @@ TEXT syscall9X(SB), NOSPLIT, $0
 
 	BL (R12)
 
-	MOVD 8(RSP), R2              // pop structure pointer
-	ADD  $16, RSP
-	MOVD R0, syscall9Args_r1(R2) // save r1
-	MOVD R1, syscall9Args_r2(R2) // save r2
+	MOVD  8(RSP), R2              // pop structure pointer
+	ADD   $16, RSP
+	MOVD  R0, syscall9Args_r1(R2) // save r1
+	FMOVD F0, syscall9Args_r2(R2) // save r2
 	RET
 
 // runtime·cgocallback expects a call to the ABIInternal function


### PR DESCRIPTION
We originally discussed this change (#48) and decided against doing it because r2 usually returns the upper 32bits of a 64bit return value on 32bit platforms. However, on Windows amd64 r2 is actually the float return value.

https://github.com/golang/go/blob/7717ac151ae1556541dddc6a817ac04733f1af44/src/runtime/sys_windows_amd64.s#L66

And there is a TODO for arm64 as well.

https://github.com/golang/go/blob/2cea6cdb6016708e89c9472cdb0504731699681d/src/runtime/sys_windows_arm64.s#L91

Doing this makes supporting float returns easier without having to implement a full C calling convention for RegisterFunc. 