### PR TITLE
purego: support float arguments in RegisterFunc

### DIFF
--- a/func_darwin.go
+++ b/func_darwin.go
@@ -71,6 +71,7 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 	if cfn == 0 {
 		panic("purego: cfn is nil")
 	}
+	// TODO: check to make sure there aren't too many arguments
 	v := reflect.MakeFunc(ty, func(args []reflect.Value) (results []reflect.Value) {
 		if len(args) > 0 {
 			if variadic, ok := args[len(args)-1].Interface().([]interface{}); ok {
@@ -93,9 +94,6 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 			runtime.KeepAlive(keepAlive)
 		}()
 		for _, v := range args {
-			if numInts >= maxArgs {
-				panic("purego: too many arguments")
-			}
 			switch v.Kind() {
 			case reflect.String:
 				ptr := strings.CString(v.String())
@@ -127,6 +125,7 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 					floats[numFloats] = v.Float()
 					numFloats++
 				} else {
+					// TODO: these should be on the stack not integer registers
 					sysargs[numInts] = uintptr(math.Float64bits(v.Float()))
 					numInts++
 				}
@@ -134,7 +133,7 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 				panic("purego: unsupported kind: " + v.Kind().String())
 			}
 		}
-		//TODO: support structs
+		// TODO: support structs
 		syscall := syscall9Args{
 			cfn,
 			sysargs[0], sysargs[1], sysargs[2], sysargs[3], sysargs[4], sysargs[5], sysargs[6], sysargs[7], sysargs[8],

--- a/func_darwin.go
+++ b/func_darwin.go
@@ -73,7 +73,7 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 	}
 	{
 		// this code checks how many registers and stack this function will use
-		// to avoid crashing with to many arguments
+		// to avoid crashing with too many arguments
 		var ints = 0
 		var floats = 0
 		var stack = 0

--- a/func_darwin.go
+++ b/func_darwin.go
@@ -116,12 +116,13 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 			}
 		}
 		var sysargs [maxArgs]uintptr
+		var stack = sysargs[numOfIntegerRegisters():]
 		var floats [8]float64
 		numInts := 0
 		numFloats := 0
 		numStack := 0
 		addStack := func(x uintptr) {
-			sysargs[numStack+numOfIntegerRegisters()] = x
+			stack[numStack] = x
 			numStack++
 		}
 		addInt := func(x uintptr) {

--- a/func_darwin.go
+++ b/func_darwin.go
@@ -74,9 +74,9 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 	{
 		// this code checks how many registers and stack this function will use
 		// to avoid crashing with too many arguments
-		var ints = 0
-		var floats = 0
-		var stack = 0
+		var ints int
+		var floats int
+		var stack int
 		for i := 0; i < ty.NumIn(); i++ {
 			arg := ty.In(i)
 			switch arg.Kind() {
@@ -118,9 +118,9 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 		var sysargs [maxArgs]uintptr
 		var stack = sysargs[numOfIntegerRegisters():]
 		var floats [8]float64
-		numInts := 0
-		numFloats := 0
-		numStack := 0
+		var numInts int
+		var numFloats int
+		var numStack int
 		addStack := func(x uintptr) {
 			stack[numStack] = x
 			numStack++

--- a/func_darwin.go
+++ b/func_darwin.go
@@ -73,7 +73,7 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 	}
 	{
 		// this code checks how many registers and stack this function will use
-		// to avoid
+		// to avoid crashing with to many arguments
 		var ints = 0
 		var floats = 0
 		var stack = 0

--- a/sys_darwin_amd64.s
+++ b/sys_darwin_amd64.s
@@ -31,28 +31,27 @@ TEXT syscall9X(SB), NOSPLIT, $0
 	PUSHQ BP
 	MOVQ  SP, BP
 	SUBQ  $32, SP
-	MOVQ  DI, 24(BP)               // save the pointer
-	MOVQ  syscall9Args_fn(DI), R10 // fn
-	MOVQ  syscall9Args_a2(DI), SI  // a2
-	MOVQ  syscall9Args_a3(DI), DX  // a3
-	MOVQ  syscall9Args_a4(DI), CX  // a4
-	MOVQ  syscall9Args_a5(DI), R8  // a5
-	MOVQ  syscall9Args_a6(DI), R9  // a6
-	MOVQ  syscall9Args_a7(DI), R11 // a7
-	MOVQ  syscall9Args_a8(DI), R12 // a8
-	MOVQ  syscall9Args_a9(DI), R13 // a9
-	MOVQ  syscall9Args_a1(DI), DI  // a1
+	MOVQ  DI, 24(BP) // save the pointer
 
-	// these may be float arguments
-	// so we put them also where C expects floats
-	MOVQ DI, X0  // a1
-	MOVQ SI, X1  // a2
-	MOVQ DX, X2  // a3
-	MOVQ CX, X3  // a4
-	MOVQ R8, X4  // a5
-	MOVQ R9, X5  // a6
-	MOVQ R11, X6 // a7
-	MOVQ R12, X7 // a8
+	MOVQ syscall9Args_f1(DI), X0 // f1
+	MOVQ syscall9Args_f2(DI), X1 // f2
+	MOVQ syscall9Args_f3(DI), X2 // f3
+	MOVQ syscall9Args_f4(DI), X3 // f4
+	MOVQ syscall9Args_f5(DI), X4 // f5
+	MOVQ syscall9Args_f6(DI), X5 // f6
+	MOVQ syscall9Args_f7(DI), X6 // f7
+	MOVQ syscall9Args_f8(DI), X7 // f8
+
+	MOVQ syscall9Args_fn(DI), R10 // fn
+	MOVQ syscall9Args_a2(DI), SI  // a2
+	MOVQ syscall9Args_a3(DI), DX  // a3
+	MOVQ syscall9Args_a4(DI), CX  // a4
+	MOVQ syscall9Args_a5(DI), R8  // a5
+	MOVQ syscall9Args_a6(DI), R9  // a6
+	MOVQ syscall9Args_a7(DI), R11 // a7
+	MOVQ syscall9Args_a8(DI), R12 // a8
+	MOVQ syscall9Args_a9(DI), R13 // a9
+	MOVQ syscall9Args_a1(DI), DI  // a1
 
 	// push the remaining paramters onto the stack
 	MOVQ R11, 0(SP)  // push a7

--- a/sys_darwin_arm64.s
+++ b/sys_darwin_arm64.s
@@ -31,6 +31,15 @@ TEXT syscall9X(SB), NOSPLIT, $0
 	SUB  $16, RSP   // push structure pointer
 	MOVD R0, 8(RSP)
 
+	FMOVD syscall9Args_f1(R0), F0 // f1
+	FMOVD syscall9Args_f2(R0), F1 // f2
+	FMOVD syscall9Args_f3(R0), F2 // f3
+	FMOVD syscall9Args_f4(R0), F3 // f4
+	FMOVD syscall9Args_f5(R0), F4 // f5
+	FMOVD syscall9Args_f6(R0), F5 // f6
+	FMOVD syscall9Args_f7(R0), F6 // f7
+	FMOVD syscall9Args_f8(R0), F7 // f8
+
 	MOVD syscall9Args_fn(R0), R12 // fn
 	MOVD syscall9Args_a2(R0), R1  // a2
 	MOVD syscall9Args_a3(R0), R2  // a3
@@ -41,17 +50,6 @@ TEXT syscall9X(SB), NOSPLIT, $0
 	MOVD syscall9Args_a8(R0), R7  // a8
 	MOVD syscall9Args_a9(R0), R8  // a9
 	MOVD syscall9Args_a1(R0), R0  // a1
-
-	// these may be float arguments
-	// so we put them also where C expects floats
-	FMOVD R0, F0 // a1
-	FMOVD R1, F1 // a2
-	FMOVD R2, F2 // a3
-	FMOVD R3, F3 // a4
-	FMOVD R4, F4 // a5
-	FMOVD R5, F5 // a6
-	FMOVD R6, F6 // a7
-	FMOVD R7, F7 // a8
 
 	MOVD R8, (RSP) // push a9 onto stack
 

--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -4,6 +4,7 @@
 package purego
 
 import (
+	"math"
 	"reflect"
 	"runtime"
 	"sync"
@@ -12,11 +13,19 @@ import (
 
 var syscall9XABI0 uintptr
 
-type syscall9Args struct{ fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, r1, r2, err uintptr }
+type syscall9Args struct {
+	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr
+	f1, f2, f3, f4, f5, f6, f7, f8         float64
+	r1, r2, err                            uintptr
+}
 
 //go:nosplit
 func syscall_syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr) {
-	args := syscall9Args{fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, r1, r2, err}
+	args := syscall9Args{fn, a1, a2, a3, a4, a5, a6, a7, a8, a9,
+		math.Float64frombits(uint64(a1)), math.Float64frombits(uint64(a2)), math.Float64frombits(uint64(a3)),
+		math.Float64frombits(uint64(a4)), math.Float64frombits(uint64(a5)), math.Float64frombits(uint64(a6)),
+		math.Float64frombits(uint64(a7)), math.Float64frombits(uint64(a8)),
+		r1, r2, err}
 	runtime_cgocall(syscall9XABI0, unsafe.Pointer(&args))
 	return args.r1, args.r2, args.err
 }


### PR DESCRIPTION
This PR adds proper float support into RegisterFunc. It puts the first 8 in registers and the 9th onto the stack. It also checks beforehand that there aren't too many arguments.