### PR TITLE
internal/fakecgo: circumvent Go 1.20's race code

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -6,9 +6,19 @@
 package main
 
 import (
+	"os"
+
 	_ "github.com/ebitengine/purego"
 )
 
 func main() {
-	// TODO: Add an implementation. This example exists only for testing so far.
+	// set and unset an environment variable since this calls into fakecgo.
+	err := os.Setenv("TESTING", "SOMETHING")
+	if err != nil {
+		panic(err)
+	}
+	err = os.Unsetenv("TESTING")
+	if err != nil {
+		panic(err)
+	}
 }

--- a/internal/fakecgo/callbacks.go
+++ b/internal/fakecgo/callbacks.go
@@ -41,3 +41,18 @@ var _cgo_notify_runtime_init_done = &x_cgo_notify_runtime_init_done_trampoline
 
 // TODO: decide if we need x_cgo_set_context_function
 // TODO: decide if we need _cgo_yield
+
+var (
+	// In Go 1.20 the race detector was rewritten to pure Go
+	// on darwin. This means that when CGO_ENABLED=0 is set
+	// fakecgo is built with race detector code. This is not
+	// good since this code is pretending to be C. The
+	// go:norace comments are not enough since the ABI wrappers
+	// still have race code. These variables will circumvent
+	// that issue by calling the function directly.
+	threadentry_call        = threadentry
+	x_cgo_init_call         = x_cgo_init
+	x_cgo_setenv_call       = x_cgo_setenv
+	x_cgo_unsetenv_call     = x_cgo_unsetenv
+	x_cgo_thread_start_call = x_cgo_thread_start
+)

--- a/internal/fakecgo/go_darwin_amd64.go
+++ b/internal/fakecgo/go_darwin_amd64.go
@@ -7,6 +7,7 @@ package fakecgo
 import "unsafe"
 
 //go:nosplit
+//go:norace
 func _cgo_sys_thread_start(ts *ThreadStart) {
 	var attr pthread_attr_t
 	var ign, oset sigset_t
@@ -41,6 +42,7 @@ var x_threadentry_trampoline byte
 var threadentry_trampolineABI0 = &x_threadentry_trampoline
 
 //go:nosplit
+//go:norace
 func threadentry(v unsafe.Pointer) unsafe.Pointer {
 	ts := *(*ThreadStart)(v)
 	free(v)
@@ -58,6 +60,7 @@ func threadentry(v unsafe.Pointer) unsafe.Pointer {
 var setg_func uintptr
 
 //go:nosplit
+//go:norace
 func x_cgo_init(g *G, setg uintptr) {
 	var size size_t
 	var attr pthread_attr_t

--- a/internal/fakecgo/go_darwin_arm64.go
+++ b/internal/fakecgo/go_darwin_arm64.go
@@ -7,6 +7,7 @@ package fakecgo
 import "unsafe"
 
 //go:nosplit
+//go:norace
 func _cgo_sys_thread_start(ts *ThreadStart) {
 	var attr pthread_attr_t
 	var ign, oset sigset_t
@@ -41,6 +42,7 @@ var x_threadentry_trampoline byte
 var threadentry_trampolineABI0 = &x_threadentry_trampoline
 
 //go:nosplit
+//go:norace
 func threadentry(v unsafe.Pointer) unsafe.Pointer {
 	ts := *(*ThreadStart)(v)
 	free(v)
@@ -67,6 +69,7 @@ var setg_func uintptr
 // This function can't be go:systemstack since go is not in a state where the systemcheck would work.
 //
 //go:nosplit
+//go:norace
 func x_cgo_init(g *G, setg uintptr) {
 	var size size_t
 	var attr pthread_attr_t

--- a/internal/fakecgo/go_libinit.go
+++ b/internal/fakecgo/go_libinit.go
@@ -19,6 +19,7 @@ func x_cgo_notify_runtime_init_done() {
 // EAGAIN.
 //
 //go:nosplit
+//go:norace
 func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe.Pointer, arg *ThreadStart) int {
 	var ts syscall.Timespec
 	// tries needs to be the same type as syscall.Timespec.Nsec

--- a/internal/fakecgo/go_setenv.go
+++ b/internal/fakecgo/go_setenv.go
@@ -6,11 +6,13 @@
 package fakecgo
 
 //go:nosplit
+//go:norace
 func x_cgo_setenv(arg *[2]*byte) {
 	setenv(arg[0], arg[1], 1)
 }
 
 //go:nosplit
+//go:norace
 func x_cgo_unsetenv(arg *[1]*byte) {
 	unsetenv(arg[0])
 }

--- a/internal/fakecgo/go_util.go
+++ b/internal/fakecgo/go_util.go
@@ -16,6 +16,7 @@ import "unsafe"
 // This function should be go:systemstack instead of go:nosplit (but that requires runtime)
 //
 //go:nosplit
+//go:norace
 func x_cgo_thread_start(arg *ThreadStart) {
 	var ts *ThreadStart
 	// Make our own copy that can persist after we return.

--- a/internal/fakecgo/trampolines_amd64.s
+++ b/internal/fakecgo/trampolines_amd64.s
@@ -29,24 +29,32 @@ return value will be in AX
 // these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
 
 TEXT x_cgo_init_trampoline(SB), NOSPLIT, $16
-	MOVQ DI, 0(SP)
-	MOVQ SI, 8(SP)
-	CALL ·x_cgo_init(SB)
+	MOVQ DI, AX
+	MOVQ SI, BX
+	MOVQ ·x_cgo_init_call(SB), DX
+	MOVQ (DX), CX
+	CALL CX
 	RET
 
 TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $8
-	MOVQ DI, 0(SP)
-	CALL ·x_cgo_thread_start(SB)
+	MOVQ DI, AX
+	MOVQ ·x_cgo_thread_start_call(SB), DX
+	MOVQ (DX), CX
+	CALL CX
 	RET
 
 TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $8
-	MOVQ DI, 0(SP)
-	CALL ·x_cgo_setenv(SB)
+	MOVQ DI, AX
+	MOVQ ·x_cgo_setenv_call(SB), DX
+	MOVQ (DX), CX
+	CALL CX
 	RET
 
 TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $8
-	MOVQ DI, 0(SP)
-	CALL ·x_cgo_unsetenv(SB)
+	MOVQ DI, AX
+	MOVQ ·x_cgo_unsetenv_call(SB), DX
+	MOVQ (DX), CX
+	CALL CX
 	RET
 
 TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT, $0
@@ -61,9 +69,10 @@ TEXT ·setg_trampoline(SB), NOSPLIT, $0-16
 	RET
 
 TEXT threadentry_trampoline(SB), NOSPLIT, $16
-	MOVQ DI, 0(SP)
-	CALL ·threadentry(SB)
-	MOVQ 8(SP), AX
+	MOVQ DI, AX
+	MOVQ ·threadentry_call(SB), DX
+	MOVQ (DX), CX
+	CALL CX
 	RET
 
 TEXT ·call5(SB), NOSPLIT, $0-0

--- a/internal/fakecgo/trampolines_arm64.s
+++ b/internal/fakecgo/trampolines_arm64.s
@@ -11,22 +11,30 @@
 TEXT x_cgo_init_trampoline(SB), NOSPLIT, $0-0
 	MOVD R0, 8(RSP)
 	MOVD R1, 16(RSP)
-	CALL ·x_cgo_init(SB)
+	MOVD ·x_cgo_init_call(SB), R26
+	MOVD (R26), R2
+	CALL (R2)
 	RET
 
 TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $0-0
 	MOVD R0, 8(RSP)
-	CALL ·x_cgo_thread_start(SB)
+	MOVD ·x_cgo_thread_start_call(SB), R26
+	MOVD (R26), R2
+	CALL (R2)
 	RET
 
 TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $0-0
 	MOVD R0, 8(RSP)
-	CALL ·x_cgo_setenv(SB)
+	MOVD ·x_cgo_setenv_call(SB), R26
+	MOVD (R26), R2
+	CALL (R2)
 	RET
 
 TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $0-0
 	MOVD R0, 8(RSP)
-	CALL ·x_cgo_unsetenv(SB)
+	MOVD ·x_cgo_unsetenv_call(SB), R26
+	MOVD (R26), R2
+	CALL (R2)
 	RET
 
 TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT, $0-0
@@ -42,8 +50,10 @@ TEXT ·setg_trampoline(SB), NOSPLIT, $0-16
 
 TEXT threadentry_trampoline(SB), NOSPLIT, $0-0
 	MOVD R0, 8(RSP)
-	CALL ·threadentry(SB)
-	MOVD $0, R0           // TODO: get the return value from threadentry
+	MOVD ·threadentry_call(SB), R26
+	MOVD (R26), R2
+	CALL (R2)
+	MOVD $0, R0                     // TODO: get the return value from threadentry
 	RET
 
 TEXT ·call5(SB), NOSPLIT, $0-0


### PR DESCRIPTION
Go 1.20 rewrote the race detector on darwin to be entirely Go. This means that fakecgo was having race functions placed inside of it which made it break. This PR circumvents the race functions by adding `//go:norace` and using closures to skip the ABI wrappers.

Closes #71