### PR TITLE
.github/workflows: enable go-test with -race for Go 1.21 and the future

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,6 @@ jobs:
           go test -shuffle=on -v -count=10 ./...
 
       - name: go test race
-        if: ${{ matrix.go == '1.20.0-rc.1' }}
+        if: ${{ !startsWith(matrix.go, '1.18.') && !startsWith(matrix.go, '1.19.') }}
         run: |
           go test -race -shuffle=on -v -count=10 ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.18.x', '1.19.x', '1.20.0-rc.1']]
+        go: ['1.18.x', '1.19.x', '1.20.0-rc.1']
     name: Test with Go ${{ matrix.go }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:


### PR DESCRIPTION
Updates #74