### PR TITLE
cleanup assembly

### DIFF
--- a/internal/fakecgo/trampolines_amd64.s
+++ b/internal/fakecgo/trampolines_amd64.s
@@ -75,13 +75,14 @@ TEXT threadentry_trampoline(SB), NOSPLIT, $16
 	CALL CX
 	RET
 
-TEXT ·call5(SB), NOSPLIT, $0-0
-	MOVQ fn+0(FP), AX
+TEXT ·call5(SB), NOSPLIT, $0-56
+	MOVQ fn+0(FP), BX
 	MOVQ a1+8(FP), DI
 	MOVQ a2+16(FP), SI
 	MOVQ a3+24(FP), DX
 	MOVQ a4+32(FP), CX
 	MOVQ a5+40(FP), R8
-	CALL AX
+	XORL AX, AX
+	CALL BX
 	MOVQ AX, ret+48(FP)
 	RET

--- a/sys_darwin_arm64.s
+++ b/sys_darwin_arm64.s
@@ -90,10 +90,10 @@ TEXT callbackasm1(SB), NOSPLIT, $208-0
 	// Move parameters into registers
 	// Get the ABIInternal function pointer
 	// without <ABIInternal> by using a closure.
-	MOVD ·callbackWrap_call(SB), R26
-	MOVD (R26), R0                   // fn unsafe.Pointer
-	MOVD R13, R1                     // frame (&callbackArgs{...})
-	MOVD $0, R3                      // ctxt uintptr
+	MOVD ·callbackWrap_call(SB), R0
+	MOVD (R0), R0                   // fn unsafe.Pointer
+	MOVD R13, R1                    // frame (&callbackArgs{...})
+	MOVD $0, R3                     // ctxt uintptr
 
 	BL crosscall2(SB)
 


### PR DESCRIPTION
On amd64, AX should be zero. This commit replaces AX with BX and then zeros AX.

On arm64, R26 is a callee-saved register. Replace R26 with R0 as that register is about to be overwritten anyways.