### PR TITLE
purego: fakecgo: align stack before call

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,8 @@ jobs:
 
       - name: go test
         run: |
-          go test -shuffle=on -v -count=10 ./...
+          env CGO_ENABLED=0 go test -shuffle=on -v -count=10 ./...
+          env CGO_ENABLED=1 go test -shuffle=on -v -count=10 ./...
 
       - name: go test race
         if: ${{ !startsWith(matrix.go, '1.18.') && !startsWith(matrix.go, '1.19.') }}

--- a/internal/fakecgo/trampolines_linux_amd64.s
+++ b/internal/fakecgo/trampolines_linux_amd64.s
@@ -68,7 +68,17 @@ TEXT ·call5(SB), NOSPLIT, $0-56
 	MOVQ a3+24(FP), DX
 	MOVQ a4+32(FP), CX
 	MOVQ a5+40(FP), R8
-	XORL AX, AX
+	XORL AX, AX // no floats
+
+	PUSHQ BP       // save BP
+	MOVQ  SP, BP   // save SP inside BP bc BP is callee-saved
+	SUBQ  $16, SP  // allocate space for alignment
+	ANDQ  $-16, SP // align on 16 bytes for SSE
+	
 	CALL BX
+
+	MOVQ BP, SP // get SP back
+	POPQ BP     // restore BP
+
 	MOVQ AX, ret+48(FP)
 	RET


### PR DESCRIPTION
Done as described in #106 in [this comment](https://github.com/ebitengine/purego/issues/106#issuecomment-1475247059).