### PR TITLE
dlfcn: rework error check

### DIFF
--- a/callback_test.go
+++ b/callback_test.go
@@ -31,7 +31,7 @@ func TestCallGoFromSharedLib(t *testing.T) {
 
 	lib, err := purego.Dlopen(libFileName, purego.RTLD_NOW|purego.RTLD_GLOBAL)
 	if err != nil {
-		t.Fatalf("Dlopen(%q) faled: %v", libFileName, err)
+		t.Fatalf("Dlopen(%q) failed: %v", libFileName, err)
 	}
 
 	var callCallback func(p uintptr, s string) int

--- a/dlfcn.go
+++ b/dlfcn.go
@@ -35,8 +35,8 @@ func init() {
 // Dlopen calls should be balanced with a Dlclose call.
 func Dlopen(path string, mode int) (uintptr, error) {
 	u := fnDlopen(path, mode)
-	if errStr := fnDlerror(); errStr != "" {
-		return 0, Dlerror{errStr}
+	if u == 0 {
+		return 0, Dlerror{fnDlerror()}
 	}
 	return u, nil
 }
@@ -47,8 +47,8 @@ func Dlopen(path string, mode int) (uintptr, error) {
 // when that library was loaded, Dlsym returns zero.
 func Dlsym(handle uintptr, name string) (uintptr, error) {
 	u := fnDlsym(handle, name)
-	if errStr := fnDlerror(); errStr != "" {
-		return 0, Dlerror{errStr}
+	if u == 0 {
+		return 0, Dlerror{fnDlerror()}
 	}
 	return u, nil
 }

--- a/libdlnested/nested.cpp
+++ b/libdlnested/nested.cpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023 The Ebitengine Authors
+
+#include <dlfcn.h>
+
+struct nested_libdl
+{
+    nested_libdl() {
+        // Fails for sure because a symbol cannot be named like this 
+        dlsym(RTLD_DEFAULT, "@/*<>");
+    }
+};
+
+static nested_libdl test;


### PR DESCRIPTION
This PR implements the fix described [here](https://github.com/ebitengine/purego/issues/118#issuecomment-1489992006)

The test added needs the testing environment to possess a C++ compiler, feel free to tell me if you have another idea to reproduce this behaviour without this new dependency.

Closes #118 