### PR TITLE
purego: add float32 and float64 support to callbacks

### DIFF
--- a/callback_test.go
+++ b/callback_test.go
@@ -72,3 +72,30 @@ func buildSharedLib(libFile string, sources ...string) error {
 
 	return nil
 }
+
+func TestNewCallback(t *testing.T) {
+	// This tests the maximum number of arguments a function to NewCallback can take
+	const (
+		expectCbTotal    = -3
+		expectedCbTotalF = float64(36)
+	)
+	var cbTotal int
+	var cbTotalF float64
+	imp := purego.NewCallback(func(a1, a2, a3, a4, a5, a6, a7, a8, a9 int,
+		f1, f2, f3, f4, f5, f6, f7, f8 float64) {
+		cbTotal = a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9
+		cbTotalF = f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8
+	})
+	var fn func(a1, a2, a3, a4, a5, a6, a7, a8, a9 int,
+		f1, f2, f3, f4, f5, f6, f7, f8 float64)
+	purego.RegisterFunc(&fn, imp)
+	fn(1, 2, -3, 4, -5, 6, -7, 8, -9,
+		1, 2, 3, 4, 5, 6, 7, 8)
+
+	if cbTotal != expectCbTotal {
+		t.Fatalf("cbTotal not correct got %d but wanted %d", cbTotal, expectCbTotal)
+	}
+	if cbTotalF != expectedCbTotalF {
+		t.Fatalf("cbTotal not correct got %f but wanted %f", cbTotalF, expectedCbTotalF)
+	}
+}

--- a/func.go
+++ b/func.go
@@ -99,7 +99,7 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 					stack++
 				}
 			case reflect.Float32, reflect.Float64:
-				if floats < 8 {
+				if floats < numOfFloats {
 					floats++
 				} else {
 					stack++
@@ -108,7 +108,8 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 				panic("purego: unsupported kind " + arg.Kind().String())
 			}
 		}
-		if ints+stack > maxArgs || floats+stack > maxArgs {
+		sizeOfStack := maxArgs - numOfIntegerRegisters()
+		if stack > sizeOfStack {
 			panic("purego: too many arguments")
 		}
 	}

--- a/sys_amd64.s
+++ b/sys_amd64.s
@@ -80,7 +80,7 @@ TEXT callbackasm1(SB), NOSPLIT, $0
 
 	MOVQ 0(SP), R10 // get the return SP so that we can align register args with stack args
 
-	// make space for first six arguments below the frame
+	// make space for first six int and 8 float arguments below the frame
 	ADJSP $14*8, SP
 	MOVSD X0, (1*8)(SP)
 	MOVSD X1, (2*8)(SP)

--- a/sys_amd64.s
+++ b/sys_amd64.s
@@ -81,14 +81,22 @@ TEXT callbackasm1(SB), NOSPLIT, $0
 	MOVQ 0(SP), R10 // get the return SP so that we can align register args with stack args
 
 	// make space for first six arguments below the frame
-	ADJSP $6*8, SP
-	MOVQ  DI, 8(SP)
-	MOVQ  SI, 16(SP)
-	MOVQ  DX, 24(SP)
-	MOVQ  CX, 32(SP)
-	MOVQ  R8, 40(SP)
-	MOVQ  R9, 48(SP)
-	LEAQ  8(SP), R8  // R8 = address of args vector
+	ADJSP $14*8, SP
+	MOVSD X0, (1*8)(SP)
+	MOVSD X1, (2*8)(SP)
+	MOVSD X2, (3*8)(SP)
+	MOVSD X3, (4*8)(SP)
+	MOVSD X4, (5*8)(SP)
+	MOVSD X5, (6*8)(SP)
+	MOVSD X6, (7*8)(SP)
+	MOVSD X7, (8*8)(SP)
+	MOVQ  DI, (9*8)(SP)
+	MOVQ  SI, (10*8)(SP)
+	MOVQ  DX, (11*8)(SP)
+	MOVQ  CX, (12*8)(SP)
+	MOVQ  R8, (13*8)(SP)
+	MOVQ  R9, (14*8)(SP)
+	LEAQ  8(SP), R8      // R8 = address of args vector
 
 	MOVQ R10, 0(SP) // push the stack pointer below registers
 
@@ -128,7 +136,7 @@ TEXT callbackasm1(SB), NOSPLIT, $0
 
 	MOVQ 0(SP), R10 // get the SP back
 
-	ADJSP $-6*8, SP // remove arguments
+	ADJSP $-14*8, SP // remove arguments
 
 	MOVQ R10, 0(SP)
 

--- a/sys_arm64.s
+++ b/sys_arm64.s
@@ -71,24 +71,32 @@ TEXT callbackasm1(SB), NOSPLIT|NOFRAME, $0
 
 	// Save callback register arguments R0-R7.
 	// We do this at the top of the frame so they're contiguous with stack arguments.
-	SUB $(8*8), RSP, R14
-	STP  (R0, R1), (0*8)(R14)
-	STP  (R2, R3), (2*8)(R14)
-	STP  (R4, R5), (4*8)(R14)
-	STP  (R6, R7), (6*8)(R14)
+	SUB   $(16*8), RSP, R14
+	FMOVD F0, (0*8)(R14)
+	FMOVD F1, (1*8)(R14)
+	FMOVD F2, (2*8)(R14)
+	FMOVD F3, (3*8)(R14)
+	FMOVD F4, (4*8)(R14)
+	FMOVD F5, (5*8)(R14)
+	FMOVD F6, (6*8)(R14)
+	FMOVD F7, (7*8)(R14)
+	STP   (R0, R1), (8*8)(R14)
+	STP   (R2, R3), (10*8)(R14)
+	STP   (R4, R5), (12*8)(R14)
+	STP   (R6, R7), (14*8)(R14)
 
 	// Adjust SP by frame size.
 	// crosscall2 clobbers FP in the frame record so only save/restore SP.
-	SUB $(28*8), RSP
+	SUB  $(28*8), RSP
 	MOVD R30, (RSP)
 
 	// Create a struct callbackArgs on our stack.
-	ADD $(callbackArgs__size + 3*8), RSP, R13
-	MOVD R12, callbackArgs_index(R13)               // callback index
+	ADD  $(callbackArgs__size + 3*8), RSP, R13
+	MOVD R12, callbackArgs_index(R13)          // callback index
 	MOVD R14, R0
-	MOVD R0, callbackArgs_args(R13)                 // address of args vector
+	MOVD R0, callbackArgs_args(R13)            // address of args vector
 	MOVD $0, R0
-	MOVD R0, callbackArgs_result(R13)               // result
+	MOVD R0, callbackArgs_result(R13)          // result
 
 	// Move parameters into registers
 	// Get the ABIInternal function pointer
@@ -101,11 +109,11 @@ TEXT callbackasm1(SB), NOSPLIT|NOFRAME, $0
 	BL crosscall2(SB)
 
 	// Get callback result.
-	ADD $(callbackArgs__size + 3*8), RSP, R13
+	ADD  $(callbackArgs__size + 3*8), RSP, R13
 	MOVD callbackArgs_result(R13), R0
 
 	// Restore SP
 	MOVD (RSP), R30
-	ADD $(28*8), RSP
+	ADD  $(28*8), RSP
 
 	RET


### PR DESCRIPTION
This commit adds support for float32 and float64 arguments in C callbacks. It also adds a test to check the maximum number of arguments a callback can have and that it is callback properly by purego. There is also some formatting done to the assembly.