### PR TITLE
purego: enable testing of amd64 with Rosseta on arm64 macOS

### DIFF
--- a/callback_test.go
+++ b/callback_test.go
@@ -6,12 +6,8 @@
 package purego_test
 
 import (
-	"errors"
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"unsafe"
 
@@ -24,7 +20,7 @@ func TestCallGoFromSharedLib(t *testing.T) {
 	libFileName := filepath.Join(t.TempDir(), "libcbtest.so")
 	t.Logf("Build %v", libFileName)
 
-	if err := buildSharedLib(libFileName, filepath.Join("libcbtest", "callback.c")); err != nil {
+	if err := buildSharedLib("CC", libFileName, filepath.Join("libcbtest", "callback.c")); err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(libFileName)
@@ -51,26 +47,6 @@ func TestCallGoFromSharedLib(t *testing.T) {
 			t.Fatalf("%d: callCallback() got %v want %v", i, got, want)
 		}
 	}
-}
-
-func buildSharedLib(libFile string, sources ...string) error {
-	out, err := exec.Command("go", "env", "CC").Output()
-	if err != nil {
-		return fmt.Errorf("go env error: %w", err)
-	}
-
-	cc := strings.TrimSpace(string(out))
-	if cc == "" {
-		return errors.New("CC not found")
-	}
-
-	args := append([]string{"-shared", "-Wall", "-Werror", "-o", libFile}, sources...)
-	cmd := exec.Command(cc, args...)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("compile lib: %w\n%q\n%s", err, cmd, string(out))
-	}
-
-	return nil
 }
 
 func TestNewCallbackFloat64(t *testing.T) {

--- a/dlfcn_test.go
+++ b/dlfcn_test.go
@@ -6,6 +6,7 @@
 package purego_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -99,20 +100,8 @@ func TestNestedDlopenCall(t *testing.T) {
 	libFileName := filepath.Join(t.TempDir(), "libdlnested.so")
 	t.Logf("Build %v", libFileName)
 
-	out, err := exec.Command("go", "env", "CXX").Output()
-	if err != nil {
-		t.Fatalf("go env error: %v", err)
-	}
-
-	cxx := strings.TrimSpace(string(out))
-	if cxx == "" {
-		t.Fatal("CXX not found")
-	}
-
-	args := []string{"-shared", "-Wall", "-Werror", "-o", libFileName, filepath.Join("libdlnested", "nested.cpp")}
-	cmd := exec.Command(cxx, args...)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("compile lib: %v\n%q\n%s", err, cmd, string(out))
+	if err := buildSharedLib("CXX", libFileName, filepath.Join("libdlnested", "nested.cpp")); err != nil {
+		t.Fatal(err)
 	}
 	defer os.Remove(libFileName)
 
@@ -122,4 +111,42 @@ func TestNestedDlopenCall(t *testing.T) {
 	}
 
 	purego.Dlclose(lib)
+}
+
+func buildSharedLib(compilerEnv, libFile string, sources ...string) error {
+	out, err := exec.Command("go", "env", compilerEnv).Output()
+	if err != nil {
+		return fmt.Errorf("go env error: %w", err)
+	}
+
+	compiler := strings.TrimSpace(string(out))
+	if compiler == "" {
+		return errors.New("compiler not found")
+	}
+
+	// macOS arm64 can run amd64 tests through Rossetta.
+	// Build the shared library based on the GOARCH and not
+	// the default behavior of the compiler.
+	var archFlag, arch string
+	if runtime.GOOS == "darwin" {
+		archFlag = "-arch"
+		switch runtime.GOARCH {
+		case "arm64":
+			arch = "arm64"
+		case "amd64":
+			arch = "x86_64"
+		default:
+			// if GOARCH is unknown then build the shared library
+			// with the compiler's normal target.
+			archFlag = ""
+			arch = ""
+		}
+	}
+	args := append([]string{archFlag, arch, "-shared", "-Wall", "-Werror", "-o", libFile}, sources...)
+	cmd := exec.Command(compiler, args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("compile lib: %w\n%q\n%s", err, cmd, string(out))
+	}
+
+	return nil
 }

--- a/dlfcn_test.go
+++ b/dlfcn_test.go
@@ -124,6 +124,8 @@ func buildSharedLib(compilerEnv, libFile string, sources ...string) error {
 		return errors.New("compiler not found")
 	}
 
+	args := []string{"-shared", "-Wall", "-Werror", "-o", libFile}
+
 	// macOS arm64 can run amd64 tests through Rossetta.
 	// Build the shared library based on the GOARCH and not
 	// the default behavior of the compiler.
@@ -141,9 +143,9 @@ func buildSharedLib(compilerEnv, libFile string, sources ...string) error {
 			archFlag = ""
 			arch = ""
 		}
+		args = append(args, archFlag, arch)
 	}
-	args := append([]string{archFlag, arch, "-shared", "-Wall", "-Werror", "-o", libFile}, sources...)
-	cmd := exec.Command(compiler, args...)
+	cmd := exec.Command(compiler, append(args, sources...)...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("compile lib: %w\n%q\n%s", err, cmd, string(out))
 	}

--- a/dlfcn_test.go
+++ b/dlfcn_test.go
@@ -116,7 +116,7 @@ func TestNestedDlopenCall(t *testing.T) {
 func buildSharedLib(compilerEnv, libFile string, sources ...string) error {
 	out, err := exec.Command("go", "env", compilerEnv).Output()
 	if err != nil {
-		return fmt.Errorf("go env error: %w", err)
+		return fmt.Errorf("go env %s error: %w", compilerEnv, err)
 	}
 
 	compiler := strings.TrimSpace(string(out))
@@ -138,10 +138,7 @@ func buildSharedLib(compilerEnv, libFile string, sources ...string) error {
 		case "amd64":
 			arch = "x86_64"
 		default:
-			// if GOARCH is unknown then build the shared library
-			// with the compiler's normal target.
-			archFlag = ""
-			arch = ""
+			return fmt.Errorf("unknown macOS architecture %s", runtime.GOARCH)
 		}
 		args = append(args, archFlag, arch)
 	}


### PR DESCRIPTION
With Rosetta on arm64 it was possible to test amd64 just by setting `GOARCH=amd64`. However, since the shared library tests were added it is no longer possible because the default compiler will build for the host architecture and not the cross-compiled (amd64) architecture. This commit tells the C/C++ compiler to build for amd64 when running an amd64 binary. This only effects macOS.