### PR TITLE
purego: check for nil callback

### DIFF
--- a/syscall_sysv.go
+++ b/syscall_sysv.go
@@ -6,7 +6,6 @@
 package purego
 
 import (
-	"fmt"
 	"reflect"
 	"runtime"
 	"sync"
@@ -125,15 +124,6 @@ var callbackWrap_call = callbackWrap
 // callbackWrap is called by assembly code which determines which Go function to call.
 // This function takes the arguments and passes them to the Go function and returns the result.
 func callbackWrap(a *callbackArgs) {
-	defer func() {
-		if err := recover(); err != nil {
-			fmt.Println(a)
-			for i, cb := range cbs.funcs[:cbs.numFn] {
-				fmt.Println(i, ":", cb)
-			}
-			panic(err)
-		}
-	}()
 	cbs.lock.Lock()
 	fn := cbs.funcs[a.index]
 	cbs.lock.Unlock()

--- a/syscall_sysv.go
+++ b/syscall_sysv.go
@@ -103,6 +103,9 @@ output:
 	}
 	cbs.lock.Lock()
 	defer cbs.lock.Unlock()
+	if cbs.numFn >= maxCB {
+		panic("purego: the maximum number of callbacks has been reached")
+	}
 	cbs.funcs[cbs.numFn] = val
 	cbs.numFn++
 	return callbackasmAddr(cbs.numFn - 1)

--- a/syscall_sysv.go
+++ b/syscall_sysv.go
@@ -22,9 +22,11 @@ type syscall9Args struct {
 
 //go:nosplit
 func syscall_syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr) {
-	args := syscall9Args{fn, a1, a2, a3, a4, a5, a6, a7, a8, a9,
+	args := syscall9Args{
+		fn, a1, a2, a3, a4, a5, a6, a7, a8, a9,
 		a1, a2, a3, a4, a5, a6, a7, a8,
-		r1, r2, err}
+		r1, r2, err,
+	}
 	runtime_cgocall(syscall9XABI0, unsafe.Pointer(&args))
 	return args.r1, args.r2, args.err
 }
@@ -73,10 +75,10 @@ type callbackArgs struct {
 func compileCallback(fn interface{}) uintptr {
 	val := reflect.ValueOf(fn)
 	if val.Kind() != reflect.Func {
-		panic("purego: type is not a function")
+		panic("purego: the type must be a function but was not")
 	}
 	if val.IsNil() {
-		panic("purego: function is nil")
+		panic("purego: function must not be nil")
 	}
 	ty := val.Type()
 	for i := 0; i < ty.NumIn(); i++ {
@@ -137,7 +139,7 @@ func callbackWrap(a *callbackArgs) {
 	var intsN int   // intsN represents the number of integer arguments processed
 	// stack points to the index into frame of the current stack element.
 	// The stack begins after the float and integer registers.
-	var stack = numOfIntegerRegisters() + numOfFloats
+	stack := numOfIntegerRegisters() + numOfFloats
 	for i := range args {
 		var pos int
 		switch fnType.In(i).Kind() {


### PR DESCRIPTION
It was possible to create a C callback for a nil function but this shouldn't be possible. This commit makes it so that NewCallback will panic on a nil function.