### PR TITLE
purego: decrease number of allocs in RegisterFunc

### DIFF
--- a/go_runtime.go
+++ b/go_runtime.go
@@ -11,3 +11,7 @@ import (
 
 //go:linkname runtime_cgocall runtime.cgocall
 func runtime_cgocall(fn uintptr, arg unsafe.Pointer) int32 // from runtime/sys_libc.go
+
+//go:linkname runtime_noescape runtime.noescape
+//go:noescape
+func runtime_noescape(p unsafe.Pointer) unsafe.Pointer

--- a/go_runtime.go
+++ b/go_runtime.go
@@ -14,4 +14,4 @@ func runtime_cgocall(fn uintptr, arg unsafe.Pointer) int32 // from runtime/sys_l
 
 //go:linkname runtime_noescape runtime.noescape
 //go:noescape
-func runtime_noescape(p unsafe.Pointer) unsafe.Pointer
+func runtime_noescape(p unsafe.Pointer) unsafe.Pointer // from runtime/stubs.go


### PR DESCRIPTION
This rewrites part of the RegisterFunc to have less code escape to the heap. Running the benchmark inside #121 shows a speed increase and alloc decrease.

```
goos: darwin
goarch: arm64
pkg: github.com/ebitengine/purego
BenchmarkCStringC
BenchmarkCStringC-10    	 2294838	       500.3 ns/op	     472 B/op	       8 allocs/op
PASS
```