### PR TITLE
objc: add safe Objc Classes

### DIFF
--- a/examples/objc/main_darwin.go
+++ b/examples/objc/main_darwin.go
@@ -27,7 +27,6 @@ func main() {
 	// @interface BarObject : NSObject <NSDelegateWindow>
 	// @property (readwrite) bar int
 	// @end
-	//
 	class, err := objc.RegisterClass(
 		"BarObject",
 		objc.GetClass("NSObject"),

--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -17,12 +17,12 @@ func CString(name string) *byte {
 	if hasSuffix(name, "\x00") {
 		return &(*(*[]byte)(unsafe.Pointer(&name)))[0]
 	}
-	var b = make([]byte, len(name)+1)
+	b := make([]byte, len(name)+1)
 	copy(b, name)
 	return &b[0]
 }
 
-// GoString copies a char* to a Go string.
+// GoString copies a null-terminated char* to a Go string.
 func GoString(c uintptr) string {
 	// We take the address and then dereference it to trick go vet from creating a possible misuse of unsafe.Pointer
 	ptr := *(*unsafe.Pointer)(unsafe.Pointer(&c))

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -283,7 +283,6 @@ func RegisterClass(name string, superClass Class, protocols []*Protocol, ivars [
 				// The following reflect code does the equivalent of this:
 				//
 				//	((*struct {
-				//		Isa Class
 				//		Padding [offset]byte
 				//		Value int
 				//	})(unsafe.Pointer(args[0].Interface().(ID)))).v = 123

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -282,7 +282,7 @@ func RegisterClass(name string, superClass Class, protocols []*Protocol, ivars [
 				switch args[2].Kind() {
 				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 					value = ID(args[2].Int())
-				case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 					value = ID(args[2].Uint())
 				case reflect.Float32, reflect.Float64:
 					value = ID(math.Float64bits(args[2].Float()))

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -278,7 +278,7 @@ func RegisterClass(name string, superClass Class, protocols []*Protocol, ivars [
 			val := reflect.MakeFunc(ty, func(args []reflect.Value) (results []reflect.Value) {
 				// on entry the first and second arguments are ID and SEL followed by the value
 				if len(args) != 3 {
-					panic(fmt.Errorf("objc: incorrect number of arguments"))
+					panic(fmt.Sprintf("objc: incorrect number of args. expected 3 got %d", len(args)))
 				}
 				// The following reflect code does the equivalent of this:
 				//
@@ -312,7 +312,7 @@ func RegisterClass(name string, superClass Class, protocols []*Protocol, ivars [
 			val := reflect.MakeFunc(ty, func(args []reflect.Value) (results []reflect.Value) {
 				// on entry the first and second arguments are ID and SEL
 				if len(args) != 2 {
-					panic(fmt.Errorf("objc: incorrect number of arguments"))
+					panic(fmt.Sprintf("objc: incorrect number of args. expected 2 got %d", len(args)))
 				}
 				id := args[0].Interface().(ID)
 				ptr := *(*unsafe.Pointer)(unsafe.Pointer(&id)) // circumvent go vet

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -210,7 +210,7 @@ type FieldDef struct {
 }
 
 // ivarRegex checks to make sure the Ivar is correctly formatted
-var ivarRegex = regexp.MustCompile("[a-z][a-zA-Z0-9]*")
+var ivarRegex = regexp.MustCompile("[a-z_][a-zA-Z0-9_]*")
 
 // RegisterClass takes the name of the class to create, the superclass, a list of protocols this class
 // implements, a list of fields this class has and a list of methods. It returns the created class or an error

--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -48,6 +48,11 @@ func ExampleRegisterClass() {
 				Type:      reflect.TypeOf(int(0)),
 				Attribute: objc.ReadWrite,
 			},
+			{
+				Name:      "foo",
+				Type:      reflect.TypeOf(false),
+				Attribute: objc.ReadWrite,
+			},
 		},
 		[]objc.MethodDef{
 			{


### PR DESCRIPTION
(now actually safe)

The issued lied in two areas. One, for loop variables take the address instead of copying the memory and taking that address. This should be fixed in 1.22. The second area of issues was caused by memory corruption occurring due to calling C functions inside of closures. 

I've tested this PR with ebitengine and all tested passed on amd64 & arm64 darwin.

Closes #143