### PR TITLE
Syscall Sysv: Add support for strings in callback arguments

### DIFF
--- a/callback_test.go
+++ b/callback_test.go
@@ -127,3 +127,17 @@ func TestNewCallbackFloat32AndFloat64(t *testing.T) {
 		t.Errorf("cbTotalF64 not correct got %f but wanted %f", cbTotalF64, expectedCbTotalF64)
 	}
 }
+
+func TestNewCallbackStringArg(t *testing.T) {
+	var got string
+	cb := purego.NewCallback(func (a string) {
+		got = a
+	})
+	var fn func(a string)
+	purego.RegisterFunc(&fn, cb)
+	passedv := "test"
+	fn(passedv)
+	if got != passedv {
+		t.Errorf("got string: %v is not equal to: %v", got, passedv)
+	}
+}


### PR DESCRIPTION
I am building bindings to a library that has callbacks with strings as arguments, therefore I added this in.

The test is very basic, so that might be improved, any ideas? Also `callback_test.go` is only run for Darwin.

I am still learning a bit about this code-base so any feedback would be helpful :^)