### PR TITLE
.github/workflows: reenable tests on branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: Test
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Now tests run only on the main branch. This is not good as stable branches are not tested.