### PR TITLE
add test for mix of floats and int arguments in callback

### DIFF
--- a/callback_test.go
+++ b/callback_test.go
@@ -80,7 +80,7 @@ func TestNewCallbackFloat64(t *testing.T) {
 func TestNewCallbackFloat64AndIntMix(t *testing.T) {
 	// This tests interleaving float and integer arguments to NewCallback
 	const (
-		expectCbTotal = 43.74
+		expectCbTotal = 54.75
 	)
 	var cbTotal float64
 	imp := purego.NewCallback(func(a1, a2 float64, a3, a4, a5 int, a6, a7, a8 float64, a9 int) {
@@ -88,7 +88,7 @@ func TestNewCallbackFloat64AndIntMix(t *testing.T) {
 	})
 	var fn func(a1, a2 float64, a3, a4, a5 int, a6, a7, a8 float64, a9 int)
 	purego.RegisterFunc(&fn, imp)
-	fn(1.5, 3.7, 5, 9, 2, 8.9, 3.4, 4.24, 6)
+	fn(1.25, 3.25, 4, 5, 6, 7.5, 8.25, 9.5, 10)
 
 	if cbTotal != expectCbTotal {
 		t.Errorf("cbTotal not correct got %f but wanted %f", cbTotal, expectCbTotal)

--- a/callback_test.go
+++ b/callback_test.go
@@ -58,7 +58,8 @@ func TestNewCallbackFloat64(t *testing.T) {
 	var cbTotal int
 	var cbTotalF float64
 	imp := purego.NewCallback(func(a1, a2, a3, a4, a5, a6, a7, a8, a9 int,
-		f1, f2, f3, f4, f5, f6, f7, f8 float64) {
+		f1, f2, f3, f4, f5, f6, f7, f8 float64,
+	) {
 		cbTotal = a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9
 		cbTotalF = f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8
 	})
@@ -76,6 +77,24 @@ func TestNewCallbackFloat64(t *testing.T) {
 	}
 }
 
+func TestNewCallbackFloat64AndIntMix(t *testing.T) {
+	// This tests interleaving float and integer arguments to NewCallback
+	const (
+		expectCbTotal = 43.74
+	)
+	var cbTotal float64
+	imp := purego.NewCallback(func(a1, a2 float64, a3, a4, a5 int, a6, a7, a8 float64, a9 int) {
+		cbTotal = a1 + a2 + float64(a3) + float64(a4) + float64(a5) + a6 + a7 + a8 + float64(a9)
+	})
+	var fn func(a1, a2 float64, a3, a4, a5 int, a6, a7, a8 float64, a9 int)
+	purego.RegisterFunc(&fn, imp)
+	fn(1.5, 3.7, 5, 9, 2, 8.9, 3.4, 4.24, 6)
+
+	if cbTotal != expectCbTotal {
+		t.Errorf("cbTotal not correct got %f but wanted %f", cbTotal, expectCbTotal)
+	}
+}
+
 func TestNewCallbackFloat32(t *testing.T) {
 	// This tests the maximum number of float32 arguments a function to NewCallback can take
 	const (
@@ -85,7 +104,8 @@ func TestNewCallbackFloat32(t *testing.T) {
 	var cbTotal int
 	var cbTotalF float32
 	imp := purego.NewCallback(func(a1, a2, a3, a4, a5, a6, a7, a8 int,
-		f1, f2, f3, f4, f5, f6, f7, f8, f9 float32) {
+		f1, f2, f3, f4, f5, f6, f7, f8, f9 float32,
+	) {
 		cbTotal = a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8
 		cbTotalF = f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8 + f9
 	})
@@ -114,7 +134,6 @@ func TestNewCallbackFloat32AndFloat64(t *testing.T) {
 	imp := purego.NewCallback(func(f1, f2, f3 float32, f4, f5, f6 float64, f7, f8, f9 float32) {
 		cbTotalF32 = f1 + f2 + f3 + f7 + f8 + f9
 		cbTotalF64 = f4 + f5 + f6
-
 	})
 	var fn func(f1, f2, f3 float32, f4, f5, f6 float64, f7, f8, f9 float32)
 	purego.RegisterFunc(&fn, imp)

--- a/func.go
+++ b/func.go
@@ -245,7 +245,7 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 			runtime_cgocall(syscall9XABI0, unsafe.Pointer(&syscall))
 			r1, r2 = syscall.r1, syscall.r2
 		} else {
-			// This is a fallback for amd64, 386, and arm. Note this may not support floats
+			// This is a fallback for Windows amd64, 386, and arm. Note this may not support floats
 			r1, r2, _ = syscall_syscall9X(cfn, sysargs[0], sysargs[1], sysargs[2], sysargs[3], sysargs[4], sysargs[5], sysargs[6], sysargs[7], sysargs[8])
 		}
 		if ty.NumOut() == 0 {


### PR DESCRIPTION
There wasn't a test for when integers and floats are interleaved in callbacks