### PR TITLE
Increase max argument to 15

### DIFF
--- a/callback_test.go
+++ b/callback_test.go
@@ -126,18 +126,18 @@ func TestNewCallbackFloat32(t *testing.T) {
 func TestNewCallbackFloat32AndFloat64(t *testing.T) {
 	// This tests that calling a function with a mix of float32 and float64 arguments works
 	const (
-		expectedCbTotalF32 = float32(30)
+		expectedCbTotalF32 = float32(72)
 		expectedCbTotalF64 = float64(48)
 	)
 	var cbTotalF32 float32
 	var cbTotalF64 float64
-	imp := purego.NewCallback(func(f1, f2, f3 float32, f4, f5, f6 float64, f7, f8, f9 float32, f10, f11, f12 float64) {
-		cbTotalF32 = f1 + f2 + f3 + f7 + f8 + f9
+	imp := purego.NewCallback(func(f1, f2, f3 float32, f4, f5, f6 float64, f7, f8, f9 float32, f10, f11, f12 float64, f13, f14, f15 float32) {
+		cbTotalF32 = f1 + f2 + f3 + f7 + f8 + f9 + f13 + f14 + f15
 		cbTotalF64 = f4 + f5 + f6 + f10 + f11 + f12
 	})
-	var fn func(f1, f2, f3 float32, f4, f5, f6 float64, f7, f8, f9 float32, f10, f11, f12 float64)
+	var fn func(f1, f2, f3 float32, f4, f5, f6 float64, f7, f8, f9 float32, f10, f11, f12 float64, f13, f14, f15 float32)
 	purego.RegisterFunc(&fn, imp)
-	fn(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+	fn(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 
 	if cbTotalF32 != expectedCbTotalF32 {
 		t.Errorf("cbTotalF32 not correct got %f but wanted %f", cbTotalF32, expectedCbTotalF32)

--- a/callback_test.go
+++ b/callback_test.go
@@ -127,17 +127,17 @@ func TestNewCallbackFloat32AndFloat64(t *testing.T) {
 	// This tests that calling a function with a mix of float32 and float64 arguments works
 	const (
 		expectedCbTotalF32 = float32(30)
-		expectedCbTotalF64 = float64(15)
+		expectedCbTotalF64 = float64(48)
 	)
 	var cbTotalF32 float32
 	var cbTotalF64 float64
-	imp := purego.NewCallback(func(f1, f2, f3 float32, f4, f5, f6 float64, f7, f8, f9 float32) {
+	imp := purego.NewCallback(func(f1, f2, f3 float32, f4, f5, f6 float64, f7, f8, f9 float32, f10, f11, f12 float64) {
 		cbTotalF32 = f1 + f2 + f3 + f7 + f8 + f9
-		cbTotalF64 = f4 + f5 + f6
+		cbTotalF64 = f4 + f5 + f6 + f10 + f11 + f12
 	})
-	var fn func(f1, f2, f3 float32, f4, f5, f6 float64, f7, f8, f9 float32)
+	var fn func(f1, f2, f3 float32, f4, f5, f6 float64, f7, f8, f9 float32, f10, f11, f12 float64)
 	purego.RegisterFunc(&fn, imp)
-	fn(1, 2, 3, 4, 5, 6, 7, 8, 9)
+	fn(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
 
 	if cbTotalF32 != expectedCbTotalF32 {
 		t.Errorf("cbTotalF32 not correct got %f but wanted %f", cbTotalF32, expectedCbTotalF32)

--- a/func.go
+++ b/func.go
@@ -236,17 +236,21 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 		var r1, r2 uintptr
 		if runtime.GOARCH == "arm64" || runtime.GOOS != "windows" {
 			// Use the normal arm64 calling convention even on Windows
-			syscall := syscall12Args{
+			syscall := syscall15Args{
 				cfn,
-				sysargs[0], sysargs[1], sysargs[2], sysargs[3], sysargs[4], sysargs[5], sysargs[6], sysargs[7], sysargs[8], sysargs[9], sysargs[10], sysargs[11],
+				sysargs[0], sysargs[1], sysargs[2], sysargs[3], sysargs[4], sysargs[5],
+				sysargs[6], sysargs[7], sysargs[8], sysargs[9], sysargs[10], sysargs[11],
+				sysargs[12], sysargs[13], sysargs[14],
 				floats[0], floats[1], floats[2], floats[3], floats[4], floats[5], floats[6], floats[7],
 				0, 0, 0,
 			}
-			runtime_cgocall(syscall12XABI0, unsafe.Pointer(&syscall))
+			runtime_cgocall(syscall15XABI0, unsafe.Pointer(&syscall))
 			r1, r2 = syscall.r1, syscall.r2
 		} else {
 			// This is a fallback for Windows amd64, 386, and arm. Note this may not support floats
-			r1, r2, _ = syscall_syscall12X(cfn, sysargs[0], sysargs[1], sysargs[2], sysargs[3], sysargs[4], sysargs[5], sysargs[6], sysargs[7], sysargs[8], sysargs[9], sysargs[10], sysargs[11])
+			r1, r2, _ = syscall_syscall15X(cfn, sysargs[0], sysargs[1], sysargs[2], sysargs[3], sysargs[4],
+				sysargs[5], sysargs[6], sysargs[7], sysargs[8], sysargs[9], sysargs[10], sysargs[11],
+				sysargs[12], sysargs[13], sysargs[14])
 		}
 		if ty.NumOut() == 0 {
 			return nil

--- a/func.go
+++ b/func.go
@@ -236,17 +236,17 @@ func RegisterFunc(fptr interface{}, cfn uintptr) {
 		var r1, r2 uintptr
 		if runtime.GOARCH == "arm64" || runtime.GOOS != "windows" {
 			// Use the normal arm64 calling convention even on Windows
-			syscall := syscall9Args{
+			syscall := syscall12Args{
 				cfn,
-				sysargs[0], sysargs[1], sysargs[2], sysargs[3], sysargs[4], sysargs[5], sysargs[6], sysargs[7], sysargs[8],
+				sysargs[0], sysargs[1], sysargs[2], sysargs[3], sysargs[4], sysargs[5], sysargs[6], sysargs[7], sysargs[8], sysargs[9], sysargs[10], sysargs[11],
 				floats[0], floats[1], floats[2], floats[3], floats[4], floats[5], floats[6], floats[7],
 				0, 0, 0,
 			}
-			runtime_cgocall(syscall9XABI0, unsafe.Pointer(&syscall))
+			runtime_cgocall(syscall12XABI0, unsafe.Pointer(&syscall))
 			r1, r2 = syscall.r1, syscall.r2
 		} else {
 			// This is a fallback for Windows amd64, 386, and arm. Note this may not support floats
-			r1, r2, _ = syscall_syscall9X(cfn, sysargs[0], sysargs[1], sysargs[2], sysargs[3], sysargs[4], sysargs[5], sysargs[6], sysargs[7], sysargs[8])
+			r1, r2, _ = syscall_syscall12X(cfn, sysargs[0], sysargs[1], sysargs[2], sysargs[3], sysargs[4], sysargs[5], sysargs[6], sysargs[7], sysargs[8], sysargs[9], sysargs[10], sysargs[11])
 		}
 		if ty.NumOut() == 0 {
 			return nil

--- a/func_test.go
+++ b/func_test.go
@@ -47,19 +47,19 @@ func TestRegisterFunc(t *testing.T) {
 }
 
 func ExampleNewCallback() {
-	cb := purego.NewCallback(func(a1, a2, a3, a4, a5, a6, a7, a8, a9 int) int {
-		fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9)
-		return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9
+	cb := purego.NewCallback(func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 int) int {
+		fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
+		return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12
 	})
 
-	var fn func(a1, a2, a3, a4, a5, a6, a7, a8, a9 int) int
+	var fn func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 int) int
 	purego.RegisterFunc(&fn, cb)
 
-	ret := fn(1, 2, 3, 4, 5, 6, 7, 8, 9)
+	ret := fn(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
 	fmt.Println(ret)
 
-	// Output: 1 2 3 4 5 6 7 8 9
-	// 45
+	// Output: 1 2 3 4 5 6 7 8 9 10 11 12
+	// 78
 }
 
 func Test_qsort(t *testing.T) {

--- a/func_test.go
+++ b/func_test.go
@@ -47,19 +47,19 @@ func TestRegisterFunc(t *testing.T) {
 }
 
 func ExampleNewCallback() {
-	cb := purego.NewCallback(func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 int) int {
-		fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
-		return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12
+	cb := purego.NewCallback(func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 int) int {
+		fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
+		return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15
 	})
 
-	var fn func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 int) int
+	var fn func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 int) int
 	purego.RegisterFunc(&fn, cb)
 
-	ret := fn(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+	ret := fn(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 	fmt.Println(ret)
 
-	// Output: 1 2 3 4 5 6 7 8 9 10 11 12
-	// 78
+	// Output: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+	// 120
 }
 
 func Test_qsort(t *testing.T) {

--- a/internal/cgo/syscall_cgo_unix.go
+++ b/internal/cgo/syscall_cgo_unix.go
@@ -16,18 +16,21 @@ package cgo
 #include <errno.h>
 #include <assert.h>
 
-typedef struct syscall12Args {
+typedef struct syscall15Args {
 	uintptr_t fn;
-	uintptr_t a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12;
+	uintptr_t a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15;
 	uintptr_t f1, f2, f3, f4, f5, f6, f7, f8;
 	uintptr_t r1, r2, err;
-} syscall12Args;
+} syscall15Args;
 
-void syscall12(struct syscall12Args *args) {
+void syscall15(struct syscall15Args *args) {
 	assert((args->f1|args->f2|args->f3|args->f4|args->f5|args->f6|args->f7|args->f8) == 0);
-	uintptr_t (*func_name)(uintptr_t a1, uintptr_t a2, uintptr_t a3, uintptr_t a4, uintptr_t a5, uintptr_t a6, uintptr_t a7, uintptr_t a8, uintptr_t a9, uintptr_t a10, uintptr_t a11, uintptr_t a12);
+	uintptr_t (*func_name)(uintptr_t a1, uintptr_t a2, uintptr_t a3, uintptr_t a4, uintptr_t a5, uintptr_t a6,
+		uintptr_t a7, uintptr_t a8, uintptr_t a9, uintptr_t a10, uintptr_t a11, uintptr_t a12,
+		uintptr_t a13, uintptr_t a14, uintptr_t a15);
 	*(void**)(&func_name) = (void*)(args->fn);
-	uintptr_t r1 =  func_name(args->a1,args->a2,args->a3,args->a4,args->a5,args->a6,args->a7,args->a8,args->a9,args->a10,args->a11,args->a12);
+	uintptr_t r1 =  func_name(args->a1,args->a2,args->a3,args->a4,args->a5,args->a6,args->a7,args->a8,args->a9,
+		args->a10,args->a11,args->a12,args->a13,args->a14,args->a15);
 	args->r1 = r1;
 	args->err = errno;
 }
@@ -36,8 +39,8 @@ void syscall12(struct syscall12Args *args) {
 import "C"
 import "unsafe"
 
-// assign purego.syscall12XABI0 to the C version of this function.
-var Syscall12XABI0 = unsafe.Pointer(C.syscall12)
+// assign purego.syscall15XABI0 to the C version of this function.
+var Syscall15XABI0 = unsafe.Pointer(C.syscall15)
 
 // all that is needed is to assign each dl function because then its
 // symbol will then be made available to the linker and linked to inside dlfcn.go
@@ -49,12 +52,13 @@ var (
 )
 
 //go:nosplit
-func Syscall12X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr) (r1, r2, err uintptr) {
-	args := C.syscall12Args{
+func Syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr) (r1, r2, err uintptr) {
+	args := C.syscall15Args{
 		C.uintptr_t(fn), C.uintptr_t(a1), C.uintptr_t(a2), C.uintptr_t(a3),
 		C.uintptr_t(a4), C.uintptr_t(a5), C.uintptr_t(a6),
-		C.uintptr_t(a7), C.uintptr_t(a8), C.uintptr_t(a9), C.uintptr_t(a10), C.uintptr_t(a11), C.uintptr_t(a12), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		C.uintptr_t(a7), C.uintptr_t(a8), C.uintptr_t(a9), C.uintptr_t(a10), C.uintptr_t(a11), C.uintptr_t(a12),
+		C.uintptr_t(a13), C.uintptr_t(a14), C.uintptr_t(a15), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	}
-	C.syscall12(&args)
+	C.syscall15(&args)
 	return uintptr(args.r1), uintptr(args.r2), uintptr(args.err)
 }

--- a/internal/cgo/syscall_cgo_unix.go
+++ b/internal/cgo/syscall_cgo_unix.go
@@ -16,18 +16,18 @@ package cgo
 #include <errno.h>
 #include <assert.h>
 
-typedef struct syscall9Args {
+typedef struct syscall12Args {
 	uintptr_t fn;
-	uintptr_t a1, a2, a3, a4, a5, a6, a7, a8, a9;
+	uintptr_t a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12;
 	uintptr_t f1, f2, f3, f4, f5, f6, f7, f8;
 	uintptr_t r1, r2, err;
-} syscall9Args;
+} syscall12Args;
 
-void syscall9(struct syscall9Args *args) {
+void syscall12(struct syscall12Args *args) {
 	assert((args->f1|args->f2|args->f3|args->f4|args->f5|args->f6|args->f7|args->f8) == 0);
-	uintptr_t (*func_name)(uintptr_t a1, uintptr_t a2, uintptr_t a3, uintptr_t a4, uintptr_t a5, uintptr_t a6, uintptr_t a7, uintptr_t a8, uintptr_t a9);
+	uintptr_t (*func_name)(uintptr_t a1, uintptr_t a2, uintptr_t a3, uintptr_t a4, uintptr_t a5, uintptr_t a6, uintptr_t a7, uintptr_t a8, uintptr_t a9, uintptr_t a10, uintptr_t a11, uintptr_t a12);
 	*(void**)(&func_name) = (void*)(args->fn);
-	uintptr_t r1 =  func_name(args->a1,args->a2,args->a3,args->a4,args->a5,args->a6,args->a7,args->a8,args->a9);
+	uintptr_t r1 =  func_name(args->a1,args->a2,args->a3,args->a4,args->a5,args->a6,args->a7,args->a8,args->a9,args->a10,args->a11,args->a12);
 	args->r1 = r1;
 	args->err = errno;
 }
@@ -36,8 +36,8 @@ void syscall9(struct syscall9Args *args) {
 import "C"
 import "unsafe"
 
-// assign purego.syscall9XABI0 to the C version of this function.
-var Syscall9XABI0 = unsafe.Pointer(C.syscall9)
+// assign purego.syscall12XABI0 to the C version of this function.
+var Syscall12XABI0 = unsafe.Pointer(C.syscall12)
 
 // all that is needed is to assign each dl function because then its
 // symbol will then be made available to the linker and linked to inside dlfcn.go
@@ -49,10 +49,12 @@ var (
 )
 
 //go:nosplit
-func Syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr) {
-	args := C.syscall9Args{C.uintptr_t(fn), C.uintptr_t(a1), C.uintptr_t(a2), C.uintptr_t(a3),
+func Syscall12X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr) (r1, r2, err uintptr) {
+	args := C.syscall12Args{
+		C.uintptr_t(fn), C.uintptr_t(a1), C.uintptr_t(a2), C.uintptr_t(a3),
 		C.uintptr_t(a4), C.uintptr_t(a5), C.uintptr_t(a6),
-		C.uintptr_t(a7), C.uintptr_t(a8), C.uintptr_t(a9), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	C.syscall9(&args)
+		C.uintptr_t(a7), C.uintptr_t(a8), C.uintptr_t(a9), C.uintptr_t(a10), C.uintptr_t(a11), C.uintptr_t(a12), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	}
+	C.syscall12(&args)
 	return uintptr(args.r1), uintptr(args.r2), uintptr(args.err)
 }

--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -12,6 +12,18 @@ import (
 	"github.com/ebitengine/purego/objc"
 )
 
+func ExampleAllocateClassPair() {
+	class := objc.AllocateClassPair(objc.GetClass("NSObject"), "FooObject", 0)
+	class.AddMethod(objc.RegisterName("run"), objc.NewIMP(func(self objc.ID, _cmd objc.SEL) {
+		fmt.Println("Hello World!")
+	}), "v@:")
+	class.Register()
+
+	fooObject := objc.ID(class).Send(objc.RegisterName("new"))
+	fooObject.Send(objc.RegisterName("run"))
+	// Output: Hello World!
+}
+
 func ExampleRegisterClass() {
 	var (
 		sel_new    = objc.RegisterName("new")

--- a/objc/objc_runtime_darwin_test.go
+++ b/objc/objc_runtime_darwin_test.go
@@ -12,18 +12,6 @@ import (
 	"github.com/ebitengine/purego/objc"
 )
 
-func ExampleAllocateClassPair() {
-	class := objc.AllocateClassPair(objc.GetClass("NSObject"), "FooObject", 0)
-	class.AddMethod(objc.RegisterName("run"), objc.NewIMP(func(self objc.ID, _cmd objc.SEL) {
-		fmt.Println("Hello World!")
-	}), "v@:")
-	class.Register()
-
-	fooObject := objc.ID(class).Send(objc.RegisterName("new"))
-	fooObject.Send(objc.RegisterName("run"))
-	// Output: Hello World!
-}
-
 func ExampleRegisterClass() {
 	var (
 		sel_new    = objc.RegisterName("new")

--- a/sys_amd64.s
+++ b/sys_amd64.s
@@ -8,8 +8,8 @@
 #include "go_asm.h"
 #include "funcdata.h"
 
-#define STACK_SIZE 96
-#define PTR_ADDRESS (STACK_SIZE - 16)
+#define STACK_SIZE 80
+#define PTR_ADDRESS (STACK_SIZE - 8)
 
 // syscall15X calls a function in libc on behalf of the syscall package.
 // syscall15X takes a pointer to a struct like:

--- a/sys_amd64.s
+++ b/sys_amd64.s
@@ -8,11 +8,11 @@
 #include "go_asm.h"
 #include "funcdata.h"
 
-#define STACK_SIZE 64
+#define STACK_SIZE 96
 #define PTR_ADDRESS (STACK_SIZE - 16)
 
-// syscall12X calls a function in libc on behalf of the syscall package.
-// syscall12X takes a pointer to a struct like:
+// syscall15X calls a function in libc on behalf of the syscall package.
+// syscall15X takes a pointer to a struct like:
 // struct {
 //	fn    uintptr
 //	a1    uintptr
@@ -27,58 +27,67 @@
 //	a10    uintptr
 //	a11    uintptr
 //	a12    uintptr
+//	a13    uintptr
+//	a14    uintptr
+//	a15    uintptr
 //	r1    uintptr
 //	r2    uintptr
 //	err   uintptr
 // }
-// syscall12X must be called on the g0 stack with the
+// syscall15X must be called on the g0 stack with the
 // C calling convention (use libcCall).
-GLOBL ·syscall12XABI0(SB), NOPTR|RODATA, $8
-DATA ·syscall12XABI0(SB)/8, $syscall12X(SB)
-TEXT syscall12X(SB), NOSPLIT|NOFRAME, $0
+GLOBL ·syscall15XABI0(SB), NOPTR|RODATA, $8
+DATA ·syscall15XABI0(SB)/8, $syscall15X(SB)
+TEXT syscall15X(SB), NOSPLIT|NOFRAME, $0
 	PUSHQ BP
 	MOVQ  SP, BP
 	SUBQ  $STACK_SIZE, SP
 	MOVQ  DI, PTR_ADDRESS(BP) // save the pointer
 	MOVQ  DI, R11
 
-	MOVQ syscall12Args_f1(R11), X0 // f1
-	MOVQ syscall12Args_f2(R11), X1 // f2
-	MOVQ syscall12Args_f3(R11), X2 // f3
-	MOVQ syscall12Args_f4(R11), X3 // f4
-	MOVQ syscall12Args_f5(R11), X4 // f5
-	MOVQ syscall12Args_f6(R11), X5 // f6
-	MOVQ syscall12Args_f7(R11), X6 // f7
-	MOVQ syscall12Args_f8(R11), X7 // f8
+	MOVQ syscall15Args_f1(R11), X0 // f1
+	MOVQ syscall15Args_f2(R11), X1 // f2
+	MOVQ syscall15Args_f3(R11), X2 // f3
+	MOVQ syscall15Args_f4(R11), X3 // f4
+	MOVQ syscall15Args_f5(R11), X4 // f5
+	MOVQ syscall15Args_f6(R11), X5 // f6
+	MOVQ syscall15Args_f7(R11), X6 // f7
+	MOVQ syscall15Args_f8(R11), X7 // f8
 
-	MOVQ syscall12Args_a1(R11), DI // a1
-	MOVQ syscall12Args_a2(R11), SI // a2
-	MOVQ syscall12Args_a3(R11), DX // a3
-	MOVQ syscall12Args_a4(R11), CX // a4
-	MOVQ syscall12Args_a5(R11), R8 // a5
-	MOVQ syscall12Args_a6(R11), R9 // a6
+	MOVQ syscall15Args_a1(R11), DI // a1
+	MOVQ syscall15Args_a2(R11), SI // a2
+	MOVQ syscall15Args_a3(R11), DX // a3
+	MOVQ syscall15Args_a4(R11), CX // a4
+	MOVQ syscall15Args_a5(R11), R8 // a5
+	MOVQ syscall15Args_a6(R11), R9 // a6
 
 	// push the remaining paramters onto the stack
-	MOVQ syscall12Args_a7(R11), R12
+	MOVQ syscall15Args_a7(R11), R12
 	MOVQ R12, 0(SP)                  // push a7
-	MOVQ syscall12Args_a8(R11), R12
+	MOVQ syscall15Args_a8(R11), R12
 	MOVQ R12, 8(SP)                  // push a8
-	MOVQ syscall12Args_a9(R11), R12
+	MOVQ syscall15Args_a9(R11), R12
 	MOVQ R12, 16(SP)                 // push a9
-	MOVQ syscall12Args_a10(R11), R12
+	MOVQ syscall15Args_a10(R11), R12
 	MOVQ R12, 24(SP)                 // push a10
-	MOVQ syscall12Args_a11(R11), R12
+	MOVQ syscall15Args_a11(R11), R12
 	MOVQ R12, 32(SP)                 // push a11
-	MOVQ syscall12Args_a12(R11), R12
+	MOVQ syscall15Args_a12(R11), R12
 	MOVQ R12, 40(SP)                 // push a12
+	MOVQ syscall15Args_a13(R11), R12
+	MOVQ R12, 48(SP)                 // push a13
+	MOVQ syscall15Args_a14(R11), R12
+	MOVQ R12, 56(SP)                 // push a14
+	MOVQ syscall15Args_a15(R11), R12
+	MOVQ R12, 64(SP)                 // push a15
 	XORL AX, AX                      // vararg: say "no float args"
 
-	MOVQ syscall12Args_fn(R11), R10 // fn
+	MOVQ syscall15Args_fn(R11), R10 // fn
 	CALL R10
 
 	MOVQ PTR_ADDRESS(BP), DI      // get the pointer back
-	MOVQ AX, syscall12Args_r1(DI) // r1
-	MOVQ X0, syscall12Args_r2(DI) // r2
+	MOVQ AX, syscall15Args_r1(DI) // r1
+	MOVQ X0, syscall15Args_r2(DI) // r2
 
 	XORL AX, AX          // no error (it's ignored anyway)
 	ADDQ $STACK_SIZE, SP

--- a/sys_amd64.s
+++ b/sys_amd64.s
@@ -8,8 +8,11 @@
 #include "go_asm.h"
 #include "funcdata.h"
 
-// syscall9X calls a function in libc on behalf of the syscall package.
-// syscall9X takes a pointer to a struct like:
+#define STACK_SIZE 64
+#define PTR_ADDRESS (STACK_SIZE - 16)
+
+// syscall12X calls a function in libc on behalf of the syscall package.
+// syscall12X takes a pointer to a struct like:
 // struct {
 //	fn    uintptr
 //	a1    uintptr
@@ -21,54 +24,64 @@
 //	a7    uintptr
 //	a8    uintptr
 //	a9    uintptr
+//	a10    uintptr
+//	a11    uintptr
+//	a12    uintptr
 //	r1    uintptr
 //	r2    uintptr
 //	err   uintptr
 // }
-// syscall9X must be called on the g0 stack with the
+// syscall12X must be called on the g0 stack with the
 // C calling convention (use libcCall).
-GLOBL ·syscall9XABI0(SB), NOPTR|RODATA, $8
-DATA ·syscall9XABI0(SB)/8, $syscall9X(SB)
-TEXT syscall9X(SB), NOSPLIT|NOFRAME, $0
+GLOBL ·syscall12XABI0(SB), NOPTR|RODATA, $8
+DATA ·syscall12XABI0(SB)/8, $syscall12X(SB)
+TEXT syscall12X(SB), NOSPLIT|NOFRAME, $0
 	PUSHQ BP
 	MOVQ  SP, BP
-	SUBQ  $32, SP
-	MOVQ  DI, 24(BP) // save the pointer
+	SUBQ  $STACK_SIZE, SP
+	MOVQ  DI, PTR_ADDRESS(BP) // save the pointer
+	MOVQ  DI, R11
 
-	MOVQ syscall9Args_f1(DI), X0 // f1
-	MOVQ syscall9Args_f2(DI), X1 // f2
-	MOVQ syscall9Args_f3(DI), X2 // f3
-	MOVQ syscall9Args_f4(DI), X3 // f4
-	MOVQ syscall9Args_f5(DI), X4 // f5
-	MOVQ syscall9Args_f6(DI), X5 // f6
-	MOVQ syscall9Args_f7(DI), X6 // f7
-	MOVQ syscall9Args_f8(DI), X7 // f8
+	MOVQ syscall12Args_f1(R11), X0 // f1
+	MOVQ syscall12Args_f2(R11), X1 // f2
+	MOVQ syscall12Args_f3(R11), X2 // f3
+	MOVQ syscall12Args_f4(R11), X3 // f4
+	MOVQ syscall12Args_f5(R11), X4 // f5
+	MOVQ syscall12Args_f6(R11), X5 // f6
+	MOVQ syscall12Args_f7(R11), X6 // f7
+	MOVQ syscall12Args_f8(R11), X7 // f8
 
-	MOVQ syscall9Args_fn(DI), R10 // fn
-	MOVQ syscall9Args_a2(DI), SI  // a2
-	MOVQ syscall9Args_a3(DI), DX  // a3
-	MOVQ syscall9Args_a4(DI), CX  // a4
-	MOVQ syscall9Args_a5(DI), R8  // a5
-	MOVQ syscall9Args_a6(DI), R9  // a6
-	MOVQ syscall9Args_a7(DI), R11 // a7
-	MOVQ syscall9Args_a8(DI), R12 // a8
-	MOVQ syscall9Args_a9(DI), R13 // a9
-	MOVQ syscall9Args_a1(DI), DI  // a1
+	MOVQ syscall12Args_a1(R11), DI // a1
+	MOVQ syscall12Args_a2(R11), SI // a2
+	MOVQ syscall12Args_a3(R11), DX // a3
+	MOVQ syscall12Args_a4(R11), CX // a4
+	MOVQ syscall12Args_a5(R11), R8 // a5
+	MOVQ syscall12Args_a6(R11), R9 // a6
 
 	// push the remaining paramters onto the stack
-	MOVQ R11, 0(SP)  // push a7
-	MOVQ R12, 8(SP)  // push a8
-	MOVQ R13, 16(SP) // push a9
-	XORL AX, AX      // vararg: say "no float args"
+	MOVQ syscall12Args_a7(R11), R12
+	MOVQ R12, 0(SP)                  // push a7
+	MOVQ syscall12Args_a8(R11), R12
+	MOVQ R12, 8(SP)                  // push a8
+	MOVQ syscall12Args_a9(R11), R12
+	MOVQ R12, 16(SP)                 // push a9
+	MOVQ syscall12Args_a10(R11), R12
+	MOVQ R12, 24(SP)                 // push a10
+	MOVQ syscall12Args_a11(R11), R12
+	MOVQ R12, 32(SP)                 // push a11
+	MOVQ syscall12Args_a12(R11), R12
+	MOVQ R12, 40(SP)                 // push a12
+	XORL AX, AX                      // vararg: say "no float args"
 
+	MOVQ syscall12Args_fn(R11), R10 // fn
 	CALL R10
 
-	MOVQ 24(BP), DI              // get the pointer back
-	MOVQ AX, syscall9Args_r1(DI) // r1
-	MOVQ X0, syscall9Args_r2(DI) // r2
+	MOVQ PTR_ADDRESS(BP), DI      // get the pointer back
+	MOVQ AX, syscall12Args_r1(DI) // r1
+	MOVQ X0, syscall12Args_r2(DI) // r2
 
-	XORL AX, AX  // no error (it's ignored anyway)
-	ADDQ $32, SP
+	XORL AX, AX          // no error (it's ignored anyway)
+	ADDQ $STACK_SIZE, SP
 	MOVQ BP, SP
 	POPQ BP
 	RET

--- a/sys_arm64.s
+++ b/sys_arm64.s
@@ -10,8 +10,8 @@
 #define STACK_SIZE 64
 #define PTR_ADDRESS (STACK_SIZE - 8)
 
-// syscall12X calls a function in libc on behalf of the syscall package.
-// syscall12X takes a pointer to a struct like:
+// syscall15X calls a function in libc on behalf of the syscall package.
+// syscall15X takes a pointer to a struct like:
 // struct {
 //	fn    uintptr
 //	a1    uintptr
@@ -26,51 +26,60 @@
 //	a10    uintptr
 //	a11    uintptr
 //	a12    uintptr
+//	a13    uintptr
+//	a14    uintptr
+//	a15    uintptr
 //	r1    uintptr
 //	r2    uintptr
 //	err   uintptr
 // }
-// syscall12X must be called on the g0 stack with the
+// syscall15X must be called on the g0 stack with the
 // C calling convention (use libcCall).
-GLOBL ·syscall12XABI0(SB), NOPTR|RODATA, $8
-DATA ·syscall12XABI0(SB)/8, $syscall12X(SB)
-TEXT syscall12X(SB), NOSPLIT, $0
+GLOBL ·syscall15XABI0(SB), NOPTR|RODATA, $8
+DATA ·syscall15XABI0(SB)/8, $syscall15X(SB)
+TEXT syscall15X(SB), NOSPLIT, $0
 	SUB  $STACK_SIZE, RSP     // push structure pointer
 	MOVD R0, PTR_ADDRESS(RSP)
 	MOVD R0, R9
 
-	FMOVD syscall12Args_f1(R9), F0 // f1
-	FMOVD syscall12Args_f2(R9), F1 // f2
-	FMOVD syscall12Args_f3(R9), F2 // f3
-	FMOVD syscall12Args_f4(R9), F3 // f4
-	FMOVD syscall12Args_f5(R9), F4 // f5
-	FMOVD syscall12Args_f6(R9), F5 // f6
-	FMOVD syscall12Args_f7(R9), F6 // f7
-	FMOVD syscall12Args_f8(R9), F7 // f8
+	FMOVD syscall15Args_f1(R9), F0 // f1
+	FMOVD syscall15Args_f2(R9), F1 // f2
+	FMOVD syscall15Args_f3(R9), F2 // f3
+	FMOVD syscall15Args_f4(R9), F3 // f4
+	FMOVD syscall15Args_f5(R9), F4 // f5
+	FMOVD syscall15Args_f6(R9), F5 // f6
+	FMOVD syscall15Args_f7(R9), F6 // f7
+	FMOVD syscall15Args_f8(R9), F7 // f8
 
-	MOVD syscall12Args_a1(R9), R0 // a1
-	MOVD syscall12Args_a2(R9), R1 // a2
-	MOVD syscall12Args_a3(R9), R2 // a3
-	MOVD syscall12Args_a4(R9), R3 // a4
-	MOVD syscall12Args_a5(R9), R4 // a5
-	MOVD syscall12Args_a6(R9), R5 // a6
-	MOVD syscall12Args_a7(R9), R6 // a7
-	MOVD syscall12Args_a8(R9), R7 // a8
+	MOVD syscall15Args_a1(R9), R0 // a1
+	MOVD syscall15Args_a2(R9), R1 // a2
+	MOVD syscall15Args_a3(R9), R2 // a3
+	MOVD syscall15Args_a4(R9), R3 // a4
+	MOVD syscall15Args_a5(R9), R4 // a5
+	MOVD syscall15Args_a6(R9), R5 // a6
+	MOVD syscall15Args_a7(R9), R6 // a7
+	MOVD syscall15Args_a8(R9), R7 // a8
 
-	MOVD syscall12Args_a9(R9), R10
+	MOVD syscall15Args_a9(R9), R10
 	MOVD R10, 0(RSP)                // push a9 onto stack
-	MOVD syscall12Args_a10(R9), R10
+	MOVD syscall15Args_a10(R9), R10
 	MOVD R10, 8(RSP)                // push a10 onto stack
-	MOVD syscall12Args_a11(R9), R10
+	MOVD syscall15Args_a11(R9), R10
 	MOVD R10, 16(RSP)               // push a11 onto stack
-	MOVD syscall12Args_a12(R9), R10
+	MOVD syscall15Args_a12(R9), R10
 	MOVD R10, 24(RSP)               // push a12 onto stack
+	MOVD syscall15Args_a13(R9), R10
+	MOVD R10, 32(RSP)               // push a13 onto stack
+	MOVD syscall15Args_a14(R9), R10
+	MOVD R10, 40(RSP)               // push a14 onto stack
+	MOVD syscall15Args_a15(R9), R10
+	MOVD R10, 48(RSP)               // push a15 onto stack
 
-	MOVD syscall12Args_fn(R9), R10 // fn
+	MOVD syscall15Args_fn(R9), R10 // fn
 	BL   (R10)
 
 	MOVD  PTR_ADDRESS(RSP), R2     // pop structure pointer
 	ADD   $STACK_SIZE, RSP
-	MOVD  R0, syscall12Args_r1(R2) // save r1
-	FMOVD F0, syscall12Args_r2(R2) // save r2
+	MOVD  R0, syscall15Args_r1(R2) // save r1
+	FMOVD F0, syscall15Args_r2(R2) // save r2
 	RET

--- a/syscall.go
+++ b/syscall.go
@@ -6,7 +6,7 @@
 package purego
 
 const (
-	maxArgs     = 12
+	maxArgs     = 15
 	numOfFloats = 8 // arm64 and amd64 both have 8 float registers
 )
 
@@ -36,5 +36,5 @@ func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 	// add padding so there is no out-of-bounds slicing
 	var tmp [maxArgs]uintptr
 	copy(tmp[:], args)
-	return syscall_syscall12X(fn, tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7], tmp[8], tmp[9], tmp[10], tmp[11])
+	return syscall_syscall15X(fn, tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7], tmp[8], tmp[9], tmp[10], tmp[11], tmp[12], tmp[13], tmp[14])
 }

--- a/syscall.go
+++ b/syscall.go
@@ -6,7 +6,7 @@
 package purego
 
 const (
-	maxArgs     = 9
+	maxArgs     = 12
 	numOfFloats = 8 // arm64 and amd64 both have 8 float registers
 )
 
@@ -36,5 +36,5 @@ func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 	// add padding so there is no out-of-bounds slicing
 	var tmp [maxArgs]uintptr
 	copy(tmp[:], args)
-	return syscall_syscall9X(fn, tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7], tmp[8])
+	return syscall_syscall12X(fn, tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7], tmp[8], tmp[9], tmp[10], tmp[11])
 }

--- a/syscall_cgo_linux.go
+++ b/syscall_cgo_linux.go
@@ -11,18 +11,18 @@ import (
 	"github.com/ebitengine/purego/internal/cgo"
 )
 
-var syscall12XABI0 = uintptr(cgo.Syscall12XABI0)
+var syscall15XABI0 = uintptr(cgo.Syscall15XABI0)
 
 // this is only here to make the assembly files happy :)
-type syscall12Args struct {
-	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr
-	f1, f2, f3, f4, f5, f6, f7, f8                        uintptr
-	r1, r2, err                                           uintptr
+type syscall15Args struct {
+	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr
+	f1, f2, f3, f4, f5, f6, f7, f8                                       uintptr
+	r1, r2, err                                                          uintptr
 }
 
 //go:nosplit
-func syscall_syscall12X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr) (r1, r2, err uintptr) {
-	return cgo.Syscall12X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
+func syscall_syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr) (r1, r2, err uintptr) {
+	return cgo.Syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
 }
 
 func NewCallback(_ interface{}) uintptr {

--- a/syscall_cgo_linux.go
+++ b/syscall_cgo_linux.go
@@ -11,18 +11,18 @@ import (
 	"github.com/ebitengine/purego/internal/cgo"
 )
 
-var syscall9XABI0 = uintptr(cgo.Syscall9XABI0)
+var syscall12XABI0 = uintptr(cgo.Syscall12XABI0)
 
 // this is only here to make the assembly files happy :)
-type syscall9Args struct {
-	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr
-	f1, f2, f3, f4, f5, f6, f7, f8         uintptr
-	r1, r2, err                            uintptr
+type syscall12Args struct {
+	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr
+	f1, f2, f3, f4, f5, f6, f7, f8                        uintptr
+	r1, r2, err                                           uintptr
 }
 
 //go:nosplit
-func syscall_syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr) {
-	return cgo.Syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9)
+func syscall_syscall12X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr) (r1, r2, err uintptr) {
+	return cgo.Syscall12X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
 }
 
 func NewCallback(_ interface{}) uintptr {

--- a/syscall_sysv.go
+++ b/syscall_sysv.go
@@ -12,22 +12,22 @@ import (
 	"unsafe"
 )
 
-var syscall9XABI0 uintptr
+var syscall12XABI0 uintptr
 
-type syscall9Args struct {
-	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr
-	f1, f2, f3, f4, f5, f6, f7, f8         uintptr
-	r1, r2, err                            uintptr
+type syscall12Args struct {
+	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr
+	f1, f2, f3, f4, f5, f6, f7, f8                        uintptr
+	r1, r2, err                                           uintptr
 }
 
 //go:nosplit
-func syscall_syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr) {
-	args := syscall9Args{
-		fn, a1, a2, a3, a4, a5, a6, a7, a8, a9,
+func syscall_syscall12X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr) (r1, r2, err uintptr) {
+	args := syscall12Args{
+		fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,
 		a1, a2, a3, a4, a5, a6, a7, a8,
 		r1, r2, err,
 	}
-	runtime_cgocall(syscall9XABI0, unsafe.Pointer(&args))
+	runtime_cgocall(syscall12XABI0, unsafe.Pointer(&args))
 	return args.r1, args.r2, args.err
 }
 

--- a/syscall_sysv.go
+++ b/syscall_sysv.go
@@ -12,22 +12,22 @@ import (
 	"unsafe"
 )
 
-var syscall12XABI0 uintptr
+var syscall15XABI0 uintptr
 
-type syscall12Args struct {
-	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr
-	f1, f2, f3, f4, f5, f6, f7, f8                        uintptr
-	r1, r2, err                                           uintptr
+type syscall15Args struct {
+	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr
+	f1, f2, f3, f4, f5, f6, f7, f8                                       uintptr
+	r1, r2, err                                                          uintptr
 }
 
 //go:nosplit
-func syscall_syscall12X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr) (r1, r2, err uintptr) {
-	args := syscall12Args{
-		fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,
+func syscall_syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr) (r1, r2, err uintptr) {
+	args := syscall15Args{
+		fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
 		a1, a2, a3, a4, a5, a6, a7, a8,
 		r1, r2, err,
 	}
-	runtime_cgocall(syscall12XABI0, unsafe.Pointer(&args))
+	runtime_cgocall(syscall15XABI0, unsafe.Pointer(&args))
 	return args.r1, args.r2, args.err
 }
 

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -10,16 +10,16 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-var syscall12XABI0 uintptr
+var syscall15XABI0 uintptr
 
-type syscall12Args struct {
-	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr
-	f1, f2, f3, f4, f5, f6, f7, f8                        uintptr
-	r1, r2, err                                           uintptr
+type syscall15Args struct {
+	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr
+	f1, f2, f3, f4, f5, f6, f7, f8                                       uintptr
+	r1, r2, err                                                          uintptr
 }
 
-func syscall_syscall12X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr) (r1, r2, err uintptr) {
-	r1, r2, errno := syscall.Syscall12(fn, 12, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
+func syscall_syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr) (r1, r2, err uintptr) {
+	r1, r2, errno := syscall.Syscall15(fn, 15, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
 	return r1, r2, uintptr(errno)
 }
 

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -10,16 +10,16 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-var syscall9XABI0 uintptr
+var syscall12XABI0 uintptr
 
-type syscall9Args struct {
-	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr
-	f1, f2, f3, f4, f5, f6, f7, f8         uintptr
-	r1, r2, err                            uintptr
+type syscall12Args struct {
+	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr
+	f1, f2, f3, f4, f5, f6, f7, f8                        uintptr
+	r1, r2, err                                           uintptr
 }
 
-func syscall_syscall9X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2, err uintptr) {
-	r1, r2, errno := syscall.Syscall9(fn, 9, a1, a2, a3, a4, a5, a6, a7, a8, a9)
+func syscall_syscall12X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 uintptr) (r1, r2, err uintptr) {
+	r1, r2, errno := syscall.Syscall12(fn, 12, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
 	return r1, r2, uintptr(errno)
 }
 


### PR DESCRIPTION
This increases the max number of arguments to be 15. This is necessary because amd64 puts almost everything on the stack when passing structs. This meant that there wasn't enough room with just 9 arguments to pass all the tests that arm64 has in the struct branch.