### PR TITLE
Expose `Dlopen` / `Dlsym` / `Dlclose` on Windows

### DIFF
--- a/dlfcn_windows.go
+++ b/dlfcn_windows.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
+
+package purego
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+const (
+	RTLD_DEFAULT = 0x00000 // Dlopen flags are not used on Windows.
+)
+
+// Dlopen examines the dynamic library or bundle file specified by path. If the file is compatible
+// with the current process and has not already been loaded into the
+// current process, it is loaded and linked. After being linked, if it contains
+// any initializer functions, they are called, before Dlopen
+// returns. It returns a handle that can be used with Dlsym and Dlclose.
+// A second call to Dlopen with the same path will return the same handle, but the internal
+// reference count for the handle will be incremented. Therefore, all
+// Dlopen calls should be balanced with a Dlclose call.
+func Dlopen(path string, _ int) (uintptr, error) {
+	return openLibrary(path)
+}
+
+// Dlsym takes a "handle" of a dynamic library returned by Dlopen and the symbol name.
+// It returns the address where that symbol is loaded into memory. If the symbol is not found,
+// in the specified library or any of the libraries that were automatically loaded by Dlopen
+// when that library was loaded, Dlsym returns zero.
+func Dlsym(handle uintptr, name string) (uintptr, error) {
+	return loadSymbol(handle, name)
+}
+
+// Dlclose decrements the reference count on the dynamic library handle.
+// If the reference count drops to zero and no other loaded libraries
+// use symbols in it, then the dynamic library is unloaded.
+func Dlclose(handle uintptr) error {
+	return windows.FreeLibrary(windows.Handle(handle))
+}

--- a/dlfcn_windows_test.go
+++ b/dlfcn_windows_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023 The Ebitengine Authors
+
+//go:build windows
+
+package purego_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ebitengine/purego"
+)
+
+func TestNestedDlopenCall(t *testing.T) {
+	libFileName := filepath.Join(t.TempDir(), "libdlnested.dll")
+	t.Logf("Build %v", libFileName)
+
+	if err := buildSharedLib("CXX", libFileName, filepath.Join("libdlnested", "nested.cpp")); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(libFileName)
+
+	lib, err := purego.Dlopen(libFileName, purego.RTLD_DEFAULT)
+	if err != nil {
+		t.Fatalf("Dlopen(%q) failed: %v", libFileName, err)
+	}
+
+	err = purego.Dlclose(lib)
+	if err != nil {
+		t.Fatalf("Dlclose(...) failed: %v", err)
+	}
+}
+
+func buildSharedLib(compilerEnv, libFile string, sources ...string) error {
+	out, err := exec.Command("go", "env", compilerEnv).Output()
+	if err != nil {
+		return fmt.Errorf("go env %s error: %w", compilerEnv, err)
+	}
+
+	compiler := strings.TrimSpace(string(out))
+	if compiler == "" {
+		return errors.New("compiler not found")
+	}
+
+	var args []string
+	if runtime.GOOS == "freebsd" {
+		args = []string{"-shared", "-Wall", "-Werror", "-fPIC", "-o", libFile}
+	} else {
+		args = []string{"-shared", "-Wall", "-Werror", "-o", libFile}
+	}
+
+	// macOS arm64 can run amd64 tests through Rossetta.
+	// Build the shared library based on the GOARCH and not
+	// the default behavior of the compiler.
+	if runtime.GOOS == "darwin" {
+		var arch string
+		switch runtime.GOARCH {
+		case "arm64":
+			arch = "arm64"
+		case "amd64":
+			arch = "x86_64"
+		default:
+			return fmt.Errorf("unknown macOS architecture %s", runtime.GOARCH)
+		}
+		args = append(args, "-arch", arch)
+	}
+	cmd := exec.Command(compiler, append(args, sources...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("compile lib: %w\n%q\n%s", err, cmd, string(out))
+	}
+
+	return nil
+}

--- a/libdlnested/nested.cpp
+++ b/libdlnested/nested.cpp
@@ -1,13 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023 The Ebitengine Authors
 
+#ifdef _WIN32
+#include <libloaderapi.h>
+#else
 #include <dlfcn.h>
+#endif
 
 struct nested_libdl
 {
     nested_libdl() {
-        // Fails for sure because a symbol cannot be named like this 
+#ifdef _WIN32
+        // Fails for sure because a symbol cannot be named like this
+        GetProcAddress(GetModuleHandleA(NULL), "@/*<>");
+#else
+        // Fails for sure because a symbol cannot be named like this
         dlsym(RTLD_DEFAULT, "@/*<>");
+#endif
     }
 };
 


### PR DESCRIPTION
Make the API consistent across platforms, so that consumers can use purego wihtout having to bother with Windows-specific shenanigans. Simply wrap `windows.LoadLibrary`, `windows.GetProcAddress` and `windows.FreeLibrary` and cast the returned values to `purego` Api types.

This makes it tremendously easier ot consume `purego` in apps that target both Windows and *NIXes.