### PR TITLE
Fix issue 189

### DIFF
--- a/buildtest/main.go
+++ b/buildtest/main.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024 The Ebitengine Authors
 
+//go:build !windows
+
 package main
 
 import (

--- a/buildtest/main.go
+++ b/buildtest/main.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024 The Ebitengine Authors
+
+package main
+
+import (
+	_ "github.com/ebitengine/purego"
+)
+
+import "C"
+
+// This file tests that build Cgo and purego at the same time succeeds to build (#189).
+func main() {
+
+}

--- a/cgo.go
+++ b/cgo.go
@@ -12,5 +12,8 @@ package purego
 // which will import this package automatically. Normally this isn't an issue since it
 // usually isn't possible to call into C without using that import. However, with purego
 // it is since we don't use `import "C"`!
-import _ "runtime/cgo"
-import _ "github.com/ebitengine/purego/internal/cgo"
+import (
+	_ "runtime/cgo"
+
+	_ "github.com/ebitengine/purego/internal/cgo"
+)

--- a/cgo.go
+++ b/cgo.go
@@ -13,3 +13,4 @@ package purego
 // usually isn't possible to call into C without using that import. However, with purego
 // it is since we don't use `import "C"`!
 import _ "runtime/cgo"
+import _ "github.com/ebitengine/purego/internal/cgo"

--- a/dlfcn_darwin.go
+++ b/dlfcn_darwin.go
@@ -12,8 +12,3 @@ const (
 	RTLD_LOCAL   = 0x4             // All symbols are not made available for relocation processing by other modules.
 	RTLD_GLOBAL  = 0x8             // All symbols are available for relocation processing of other modules.
 )
-
-//go:cgo_import_dynamic purego_dlopen dlopen "/usr/lib/libSystem.B.dylib"
-//go:cgo_import_dynamic purego_dlsym dlsym "/usr/lib/libSystem.B.dylib"
-//go:cgo_import_dynamic purego_dlerror dlerror "/usr/lib/libSystem.B.dylib"
-//go:cgo_import_dynamic purego_dlclose dlclose "/usr/lib/libSystem.B.dylib"

--- a/dlfcn_freebsd.go
+++ b/dlfcn_freebsd.go
@@ -11,8 +11,3 @@ const (
 	RTLD_LOCAL   = 0x00000         // All symbols are not made available for relocation processing by other modules.
 	RTLD_GLOBAL  = 0x00100         // All symbols are available for relocation processing of other modules.
 )
-
-//go:cgo_import_dynamic purego_dlopen dlopen "libc.so.7"
-//go:cgo_import_dynamic purego_dlsym dlsym "libc.so.7"
-//go:cgo_import_dynamic purego_dlerror dlerror "libc.so.7"
-//go:cgo_import_dynamic purego_dlclose dlclose "libc.so.7"

--- a/dlfcn_nocgo_darwin.go
+++ b/dlfcn_nocgo_darwin.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024 The Ebitengine Authors
+
+//go:build !cgo
+
+package purego
+
+//go:cgo_import_dynamic purego_dlopen dlopen "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic purego_dlsym dlsym "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic purego_dlerror dlerror "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic purego_dlclose dlclose "/usr/lib/libSystem.B.dylib"

--- a/dlfcn_nocgo_freebsd.go
+++ b/dlfcn_nocgo_freebsd.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
+
+//go:build !cgo
+
+package purego
+
+//go:cgo_import_dynamic purego_dlopen dlopen "libc.so.7"
+//go:cgo_import_dynamic purego_dlsym dlsym "libc.so.7"
+//go:cgo_import_dynamic purego_dlerror dlerror "libc.so.7"
+//go:cgo_import_dynamic purego_dlclose dlclose "libc.so.7"

--- a/dlfcn_nocgo_linux.go
+++ b/dlfcn_nocgo_linux.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build !cgo || amd64 || arm64
+//go:build !cgo
 
 package purego
 

--- a/dlfcn_stubs.s
+++ b/dlfcn_stubs.s
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build darwin || freebsd || (linux && !cgo)
+//go:build !cgo && (darwin || freebsd || linux)
 
 #include "textflag.h"
 

--- a/dlfcn_stubs.s
+++ b/dlfcn_stubs.s
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build darwin || freebsd || (linux && (!cgo || amd64 || arm64))
+//go:build darwin || freebsd || (linux && !cgo)
 
 #include "textflag.h"
 

--- a/internal/buildtest/main.go
+++ b/internal/buildtest/main.go
@@ -13,5 +13,4 @@ import "C"
 
 // This file tests that build Cgo and purego at the same time succeeds to build (#189).
 func main() {
-
 }

--- a/internal/cgo/dlfcn_cgo_unix.go
+++ b/internal/cgo/dlfcn_cgo_unix.go
@@ -11,7 +11,6 @@ package cgo
 #include <dlfcn.h>
 */
 import "C"
-import _ "unsafe" // for go:linkname
 
 // all that is needed is to assign each dl function because then its
 // symbol will then be made available to the linker and linked to inside dlfcn.go

--- a/internal/cgo/dlfcn_cgo_unix.go
+++ b/internal/cgo/dlfcn_cgo_unix.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024 The Ebitengine Authors
+
 package cgo
 
 /*

--- a/internal/cgo/dlfcn_cgo_unix.go
+++ b/internal/cgo/dlfcn_cgo_unix.go
@@ -1,0 +1,18 @@
+package cgo
+
+/*
+ #cgo LDFLAGS: -ldl
+
+#include <dlfcn.h>
+*/
+import "C"
+import _ "unsafe" // for go:linkname
+
+// all that is needed is to assign each dl function because then its
+// symbol will then be made available to the linker and linked to inside dlfcn.go
+var (
+	_ = C.dlopen
+	_ = C.dlsym
+	_ = C.dlerror
+	_ = C.dlclose
+)

--- a/internal/cgo/dlfcn_cgo_unix.go
+++ b/internal/cgo/dlfcn_cgo_unix.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024 The Ebitengine Authors
 
+//go:build darwin || freebsd || linux
+
 package cgo
 
 /*

--- a/internal/cgo/syscall_cgo_unix.go
+++ b/internal/cgo/syscall_cgo_unix.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build freebsd || linux
+//go:build freebsd || (linux && !(arm64 || amd64))
 
 package cgo
 
@@ -41,15 +41,6 @@ import "unsafe"
 
 // assign purego.syscall15XABI0 to the C version of this function.
 var Syscall15XABI0 = unsafe.Pointer(C.syscall15)
-
-// all that is needed is to assign each dl function because then its
-// symbol will then be made available to the linker and linked to inside dlfcn.go
-var (
-	_ = C.dlopen
-	_ = C.dlsym
-	_ = C.dlerror
-	_ = C.dlclose
-)
 
 //go:nosplit
 func Syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr) (r1, r2, err uintptr) {


### PR DESCRIPTION
Use the standard Cgo import mechanism when CGO_ENABLED=1. This fixes an issue where sometimes the external linker would fail to add the dlfcn symbols causing a linker error.

Closes #189