### PR TITLE
Fix Three Small Fields losing the last field

### DIFF
--- a/struct_amd64.go
+++ b/struct_amd64.go
@@ -168,8 +168,7 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 
 			if shift == 64 {
 				flush()
-			}
-			if shift > 64 {
+			} else if shift > 64 {
 				// Should never happen, but may if we forget to reset shift after flush (or forget to flush),
 				// better fall apart here, than corrupt arguments.
 				panic("purego: tryPlaceRegisters shift > 64")

--- a/struct_amd64.go
+++ b/struct_amd64.go
@@ -94,13 +94,16 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 				f = v.Index(i)
 			}
 			if shift >= 64 {
+				// not marking flushed = true even though have flushed
+				// because now we're processing a new field
+				// and if we exit now - we have to flush that field
 				shift = 0
-				flushed = true
 				if class == _SSE {
 					addFloat(uintptr(val))
 				} else {
 					addInt(uintptr(val))
 				}
+				val = 0
 				class = _NO_CLASS
 			}
 			switch f.Kind() {

--- a/struct_amd64.go
+++ b/struct_amd64.go
@@ -76,6 +76,17 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 	var shift byte // # of bits to shift
 	var flushed bool
 	class := _NO_CLASS
+	flush := func() {
+		flushed = true
+		if class == _SSE {
+			addFloat(uintptr(val))
+		} else {
+			addInt(uintptr(val))
+		}
+		val = 0
+		shift = 0
+		class = _NO_CLASS
+	}
 	var place func(v reflect.Value)
 	place = func(v reflect.Value) {
 		var numFields int
@@ -92,19 +103,6 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 				f = v.Field(i)
 			} else {
 				f = v.Index(i)
-			}
-			if shift >= 64 {
-				// not marking flushed = true even though have flushed
-				// because now we're processing a new field
-				// and if we exit now - we have to flush that field
-				shift = 0
-				if class == _SSE {
-					addFloat(uintptr(val))
-				} else {
-					addInt(uintptr(val))
-				}
-				val = 0
-				class = _NO_CLASS
 			}
 			switch f.Kind() {
 			case reflect.Struct:
@@ -131,10 +129,9 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 				shift += 32
 				class |= _INTEGER
 			case reflect.Int64:
-				addInt(uintptr(f.Int()))
-				shift = 0
-				class = _NO_CLASS
-				flushed = true
+				val = uint64(f.Int())
+				shift = 64
+				class = _INTEGER
 			case reflect.Uint8:
 				val |= f.Uint() << shift
 				shift += 8
@@ -148,10 +145,9 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 				shift += 32
 				class |= _INTEGER
 			case reflect.Uint64:
-				addInt(uintptr(f.Uint()))
-				shift = 0
-				class = _NO_CLASS
-				flushed = true
+				val = f.Uint()
+				shift = 64
+				class = _INTEGER
 			case reflect.Float32:
 				val |= uint64(math.Float32bits(float32(f.Float()))) << shift
 				shift += 32
@@ -161,24 +157,29 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 					ok = false
 					return
 				}
-				addFloat(uintptr(math.Float64bits(f.Float())))
-				class = _NO_CLASS
-				flushed = true
+				val = uint64(math.Float64bits(f.Float()))
+				shift = 64
+				class = _SSE
 			case reflect.Array:
 				place(f)
 			default:
 				panic("purego: unsupported kind " + f.Kind().String())
+			}
+
+			if shift == 64 {
+				flush()
+			}
+			if shift > 64 {
+				// Should never happen, but may if we forget to reset shift after flush (or forget to flush),
+				// better fall apart here, than corrupt arguments.
+				panic("purego: tryPlaceRegisters shift > 64")
 			}
 		}
 	}
 
 	place(v)
 	if !flushed {
-		if class == _SSE {
-			addFloat(uintptr(val))
-		} else {
-			addInt(uintptr(val))
-		}
+		flush()
 	}
 	return ok
 }

--- a/struct_test.go
+++ b/struct_test.go
@@ -119,6 +119,16 @@ func TestRegisterFunc_structArgs(t *testing.T) {
 		}
 	}
 	{
+		type ThreeSmallFields struct {
+			x, y, z float32
+		}
+		var ThreeSmallFieldsFn func(ThreeSmallFields) float32
+		purego.RegisterLibFunc(&ThreeSmallFieldsFn, lib, "ThreeSmallFields")
+		if ret := ThreeSmallFieldsFn(ThreeSmallFields{1, 2, 7}); ret != expectedFloat {
+			t.Fatalf("ThreeSmallFields returned %f wanted %f", ret, expectedFloat)
+		}
+	}
+	{
 		type FloatAndInt struct {
 			x float32
 			y int32

--- a/testdata/structtest/struct_test.c
+++ b/testdata/structtest/struct_test.c
@@ -74,6 +74,14 @@ float FloatLessThan16Bytes(struct FloatLessThan16Bytes f) {
     return f.x + f.y;
 }
 
+struct ThreeSmallFields {
+    float x, y, z;
+};
+
+float ThreeSmallFields(struct ThreeSmallFields f) {
+    return f.x + f.y + f.z;
+}
+
 struct FloatAndInt {
     float x;
     int   y;


### PR DESCRIPTION
There was a bug, that caused the last small field, that directly followed a set of small fields that combined into one full machine word, in a struct to not be added to the list of arguments.
It was caused by incorrectly marking that the field that is being processed right now is flushed if processing of previous small field resulted in `val` getting filled enough to be flushed.

In order to avoid similar errors and to have flushing logic at one place I've moved that out into an anonymous function. It should impact performance somewhat, I guess I could just inline it. Would like to hear your opinion on that!

Closes #210