### PR TITLE
all: allow running programs that import purego in the playground

### DIFF
--- a/dlfcn_nocgo_linux.go
+++ b/dlfcn_nocgo_linux.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build !cgo
+//go:build !cgo && !faketime
 
 package purego
 

--- a/dlfcn_playground.go
+++ b/dlfcn_playground.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024 The Ebitengine Authors
+
+//go:build faketime
+
+package purego
+
+import _ "unsafe"
+
+// The playground doesn't support dynamic linking so just stub out the addresses
+var (
+	//go:linkname purego_dlopen purego_dlopen
+	purego_dlopen uintptr
+	//go:linkname purego_dlsym purego_dlsym
+	purego_dlsym uintptr
+	//go:linkname purego_dlerror purego_dlerror
+	purego_dlerror uintptr
+	//go:linkname purego_dlclose purego_dlclose
+	purego_dlclose uintptr
+)


### PR DESCRIPTION
Currently, if a package imports purego in the playground even if none of the functions are called the run will fail with a complaint about unable to link in libdl.so.2. This commit circumvents this by stubbing out the dynamic linking pragmas for the go playground (`//go:build faketime`). This allows building and running apps in the playground that import purego but *doesn't* allow actually calling any of the functions. Currently, it will just die very ungracefully.

Playground: https://go.dev/play/p/t3PK-iTWSl-
Remove the replace in the go.mod to see old behavior.