### PR TITLE
all: struct return fixes

### DIFF
--- a/struct_arm64.go
+++ b/struct_arm64.go
@@ -16,17 +16,17 @@ func getStruct(outType reflect.Type, syscall syscall15Args) (v reflect.Value) {
 		return reflect.New(outType).Elem()
 	case outSize <= 8:
 		r1 := syscall.a1
-		if isAllSameFloat(outType) {
+		if isAllFloats, numFields := isAllSameFloat(outType); isAllFloats {
 			r1 = syscall.f1
-			if outType.NumField() == 2 {
+			if numFields == 2 {
 				r1 = syscall.f2<<32 | syscall.f1
 			}
 		}
 		return reflect.NewAt(outType, unsafe.Pointer(&struct{ a uintptr }{r1})).Elem()
 	case outSize <= 16:
 		r1, r2 := syscall.a1, syscall.a2
-		if isAllSameFloat(outType) {
-			switch outType.NumField() {
+		if isAllFloats, numFields := isAllSameFloat(outType); isAllFloats {
+			switch numFields {
 			case 4:
 				r1 = syscall.f2<<32 | syscall.f1
 				r2 = syscall.f4<<32 | syscall.f3
@@ -42,8 +42,8 @@ func getStruct(outType reflect.Type, syscall syscall15Args) (v reflect.Value) {
 		}
 		return reflect.NewAt(outType, unsafe.Pointer(&struct{ a, b uintptr }{r1, r2})).Elem()
 	default:
-		if isAllSameFloat(outType) && outType.NumField() <= 4 {
-			switch outType.NumField() {
+		if isAllFloats, numFields := isAllSameFloat(outType); isAllFloats && numFields <= 4 {
+			switch numFields {
 			case 4:
 				return reflect.NewAt(outType, unsafe.Pointer(&struct{ a, b, c, d uintptr }{syscall.f1, syscall.f2, syscall.f3, syscall.f4})).Elem()
 			case 3:

--- a/struct_test.go
+++ b/struct_test.go
@@ -586,6 +586,18 @@ func TestRegisterFunc_structReturns(t *testing.T) {
 		}
 	}
 	{
+		type FourDoublesInternal struct {
+			f struct{ a, b float64 }
+			g struct{ c, d float64 }
+		}
+		var ReturnFourDoublesInternal func(a, b, c, d float64) FourDoublesInternal
+		purego.RegisterLibFunc(&ReturnFourDoublesInternal, lib, "ReturnFourDoublesInternal")
+		expected := FourDoublesInternal{f: struct{ a, b float64 }{a: 1, b: 2}, g: struct{ c, d float64 }{c: 3, d: 4}}
+		if ret := ReturnFourDoublesInternal(1, 2, 3, 4); ret != expected {
+			t.Fatalf("ReturnFourDoublesInternal returned %+v wanted %+v", ret, expected)
+		}
+	}
+	{
 		type FiveDoubles struct{ a, b, c, d, e float64 }
 		var ReturnFiveDoubles func(a, b, c, d, e float64) FiveDoubles
 		purego.RegisterLibFunc(&ReturnFiveDoubles, lib, "ReturnFiveDoubles")

--- a/testdata/structtest/structreturn_test.c
+++ b/testdata/structtest/structreturn_test.c
@@ -129,6 +129,20 @@ struct FourDoubles ReturnFourDoubles(double a, double b, double c, double d) {
     return e;
 }
 
+struct FourDoublesInternal{
+    struct {
+        double a, b;
+    } f;
+    struct {
+        double c, d;
+    } g;
+};
+
+struct FourDoublesInternal ReturnFourDoublesInternal(double a, double b, double c, double d) {
+    struct FourDoublesInternal e = { {a, b}, {c, d} };
+    return e;
+}
+
 struct FiveDoubles{
     double a, b, c, d, e;
 };


### PR DESCRIPTION
On amd64, there was a crash when calling objc.Send with a struct return type. This was due to calling the wrong objc message send function.

On arm64, if a struct return contained structs that only contained floats it would expect it to be in R8 instead of the expected float registers

Closes #223