### PR TITLE
Consolidate struct definition

### DIFF
--- a/syscall.go
+++ b/syscall.go
@@ -10,6 +10,12 @@ const (
 	numOfFloats = 8 // arm64 and amd64 both have 8 float registers
 )
 
+type syscall15Args struct {
+	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr
+	f1, f2, f3, f4, f5, f6, f7, f8                                       uintptr
+	arm64_r8                                                             uintptr
+}
+
 // SyscallN takes fn, a C function pointer and a list of arguments as uintptr.
 // There is an internal maximum number of arguments that SyscallN can take. It panics
 // when the maximum is exceeded. It returns the result and the libc error code if there is one.

--- a/syscall_cgo_linux.go
+++ b/syscall_cgo_linux.go
@@ -13,14 +13,6 @@ import (
 
 var syscall15XABI0 = uintptr(cgo.Syscall15XABI0)
 
-// this is only here to make the assembly files happy :)
-type syscall15Args struct {
-	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr
-	f1, f2, f3, f4, f5, f6, f7, f8                                       uintptr
-	r1, r2, err                                                          uintptr
-	arm64_r8                                                             uintptr
-}
-
 //go:nosplit
 func syscall_syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr) (r1, r2, err uintptr) {
 	return cgo.Syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)

--- a/syscall_sysv.go
+++ b/syscall_sysv.go
@@ -14,12 +14,6 @@ import (
 
 var syscall15XABI0 uintptr
 
-type syscall15Args struct {
-	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr
-	f1, f2, f3, f4, f5, f6, f7, f8                                       uintptr
-	arm64_r8                                                             uintptr
-}
-
 //go:nosplit
 func syscall_syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr) (r1, r2, err uintptr) {
 	args := syscall15Args{

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -12,12 +12,6 @@ import (
 
 var syscall15XABI0 uintptr
 
-type syscall15Args struct {
-	fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr
-	f1, f2, f3, f4, f5, f6, f7, f8                                       uintptr
-	arm64_r8                                                             uintptr
-}
-
 func syscall_syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr) (r1, r2, err uintptr) {
 	r1, r2, errno := syscall.Syscall15(fn, 15, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
 	return r1, r2, uintptr(errno)


### PR DESCRIPTION
The struct on Cgo non-amd64 and non-arm64 platforms didn't have the struct fields updated. To avoid forgetting to update all the structs I've moved it where every platform shares the same type def.

Closes #228