### PR TITLE
Remove linkname on playground

### DIFF
--- a/dlfcn.go
+++ b/dlfcn.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build darwin || freebsd || linux
+//go:build darwin || freebsd || (linux && !faketime)
 
 package purego
 

--- a/dlfcn_playground.go
+++ b/dlfcn_playground.go
@@ -5,16 +5,20 @@
 
 package purego
 
-import _ "unsafe"
+import "errors"
 
-// The playground doesn't support dynamic linking so just stub out the addresses
-var (
-	//go:linkname purego_dlopen purego_dlopen
-	purego_dlopen uintptr
-	//go:linkname purego_dlsym purego_dlsym
-	purego_dlsym uintptr
-	//go:linkname purego_dlerror purego_dlerror
-	purego_dlerror uintptr
-	//go:linkname purego_dlclose purego_dlclose
-	purego_dlclose uintptr
-)
+func Dlopen(path string, mode int) (uintptr, error) {
+	return 0, errors.New("Dlopen is not supported in the playground")
+}
+
+func Dlsym(handle uintptr, name string) (uintptr, error) {
+	return 0, errors.New("Dlsym is not supported in the playground")
+}
+
+func Dlclose(handle uintptr) error {
+	return errors.New("Dlclose is not supported in the playground")
+}
+
+func loadSymbol(handle uintptr, name string) (uintptr, error) {
+	return Dlsym(handle, name)
+}

--- a/dlfcn_stubs.s
+++ b/dlfcn_stubs.s
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build darwin || !cgo && (freebsd ||  linux)
+//go:build darwin || !cgo && (freebsd || linux && !faketime)
 
 #include "textflag.h"
 


### PR DESCRIPTION
Currently the playground just crashes with a nasty error. This makes it so the error message is nice. It also remove linkname usages which is also good.

Updates #247