### PR TITLE
all: remove dependencies on golang.org/x/sys

### DIFF
--- a/internal/load/load_windows.go
+++ b/internal/load/load_windows.go
@@ -3,13 +3,15 @@
 
 package load
 
-import "golang.org/x/sys/windows"
+import (
+	"syscall"
+)
 
 func OpenLibrary(name string) (uintptr, error) {
-	handle, err := windows.LoadLibrary(name)
+	handle, err := syscall.LoadLibrary(name)
 	return uintptr(handle), err
 }
 
 func OpenSymbol(lib uintptr, name string) (uintptr, error) {
-	return windows.GetProcAddress(windows.Handle(lib), name)
+	return syscall.GetProcAddress(syscall.Handle(lib), name)
 }

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -6,8 +6,6 @@ package purego
 import (
 	"reflect"
 	"syscall"
-
-	"golang.org/x/sys/windows"
 )
 
 var syscall15XABI0 uintptr
@@ -44,5 +42,5 @@ func NewCallback(fn interface{}) uintptr {
 }
 
 func loadSymbol(handle uintptr, name string) (uintptr, error) {
-	return windows.GetProcAddress(windows.Handle(handle), name)
+	return syscall.GetProcAddress(syscall.Handle(handle), name)
 }


### PR DESCRIPTION
The example still has the dependency on golang.org/x/sys.

Updates #270

<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
#270 

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
Removes the dependency on golang.org/x/sys from the core.

The example still uses golang.org/x/sys.