### PR TITLE
remove golang.org/x/sys from examples and therefore completely #270

### DIFF
--- a/examples/libc/main_windows.go
+++ b/examples/libc/main_windows.go
@@ -3,9 +3,9 @@
 
 package main
 
-import "golang.org/x/sys/windows"
+import "syscall"
 
 func openLibrary(name string) (uintptr, error) {
-	handle, err := windows.LoadLibrary(name)
+	handle, err := syscall.LoadLibrary(name)
 	return uintptr(handle), err
 }

--- a/examples/window/main_windows.go
+++ b/examples/window/main_windows.go
@@ -5,9 +5,8 @@ package main
 
 import (
 	"runtime"
+	"syscall"
 	"unsafe"
-
-	"golang.org/x/sys/windows"
 
 	"github.com/ebitengine/purego"
 )
@@ -78,10 +77,10 @@ var (
 )
 
 func init() {
-	kernel32 := windows.NewLazySystemDLL("kernel32.dll").Handle()
+	kernel32 := uintptr(syscall.MustLoadDLL("kernel32.dll").Handle)
 	purego.RegisterLibFunc(&GetModuleHandle, kernel32, "GetModuleHandleW")
 
-	user32 := windows.NewLazySystemDLL("user32.dll").Handle()
+	user32 := uintptr(syscall.MustLoadDLL("user32.dll").Handle)
 	purego.RegisterLibFunc(&RegisterClassEx, user32, "RegisterClassExW")
 	purego.RegisterLibFunc(&CreateWindowEx, user32, "CreateWindowExW")
 	purego.RegisterLibFunc(&AdjustWindowRect, user32, "AdjustWindowRect")
@@ -96,7 +95,7 @@ func init() {
 }
 
 func main() {
-	className, err := windows.UTF16PtrFromString("Sample Window Class")
+	className, err := syscall.UTF16PtrFromString("Sample Window Class")
 	if err != nil {
 		panic(err)
 	}
@@ -104,7 +103,7 @@ func main() {
 
 	wc := WNDCLASSEX{
 		Size:      uint32(unsafe.Sizeof(WNDCLASSEX{})),
-		WndProc:   windows.NewCallback(wndProc),
+		WndProc:   syscall.NewCallback(wndProc),
 		Instance:  inst,
 		ClassName: className,
 	}
@@ -117,7 +116,7 @@ func main() {
 		Right:  320,
 		Bottom: 240,
 	}
-	title, err := windows.UTF16PtrFromString("My Title")
+	title, err := syscall.UTF16PtrFromString("My Title")
 	if err != nil {
 		panic(err)
 	}
@@ -130,7 +129,7 @@ func main() {
 		0, 0, inst, nil,
 	)
 	if hwnd == 0 {
-		panic(windows.GetLastError())
+		panic(syscall.GetLastError())
 	}
 
 	ShowWindow(hwnd, SW_SHOW)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/ebitengine/purego
 
 go 1.18
-
-require golang.org/x/sys v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
-golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
#270 

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
Removes golang.org/x/sys  from the examples as well.
