### PR TITLE
fakecgo: C functions require nosplit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
           # Compile without optimization to check potential stack overflow.
           # The option '-gcflags=all=-N -l' is often used at Visual Studio Code.
           # See also https://go.googlesource.com/vscode-go/+/HEAD/docs/debugging.md#launch.
-          # TODO: CGO_ENABLED=0 might cause SEGV. Fix this issue.
+          env CGO_ENABLED=0 go test "-gcflags=all=-N -l" -v ./...
           env CGO_ENABLED=1 go test "-gcflags=all=-N -l" -v ./...
 
       - name: go test (Linux arm64)

--- a/internal/fakecgo/gen.go
+++ b/internal/fakecgo/gen.go
@@ -36,6 +36,7 @@ func setg_trampoline(setg uintptr, G uintptr)
 func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
 
 {{ range . -}}
+//go:nosplit
 func {{.Name}}(
 {{- range .Args -}}
 	{{- if .Name -}}

--- a/internal/fakecgo/go_libinit.go
+++ b/internal/fakecgo/go_libinit.go
@@ -50,8 +50,10 @@ func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe
 	var err int
 
 	for tries = 0; tries < 20; tries++ {
+		// inlined this call because it ran out of stack when inlining was disabled
 		err = int(call5(pthread_createABI0, uintptr(unsafe.Pointer(thread)), uintptr(unsafe.Pointer(attr)), uintptr(pfn), uintptr(unsafe.Pointer(arg)), 0))
 		if err == 0 {
+			// inlined this call because it ran out of stack when inlining was disabled
 			call5(pthread_detachABI0, uintptr(*thread), 0, 0, 0, 0)
 			return 0
 		}
@@ -60,6 +62,7 @@ func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe
 		}
 		ts.Sec = 0
 		ts.Nsec = (tries + 1) * 1000 * 1000 // Milliseconds.
+		// inlined this call because it ran out of stack when inlining was disabled
 		call5(nanosleepABI0, uintptr(unsafe.Pointer(&ts)), 0, 0, 0, 0)
 	}
 	return int(syscall.EAGAIN)

--- a/internal/fakecgo/go_libinit.go
+++ b/internal/fakecgo/go_libinit.go
@@ -50,9 +50,9 @@ func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe
 	var err int
 
 	for tries = 0; tries < 20; tries++ {
-		err = int(pthread_create(thread, attr, pfn, unsafe.Pointer(arg)))
+		err = int(call5(pthread_createABI0, uintptr(unsafe.Pointer(thread)), uintptr(unsafe.Pointer(attr)), uintptr(pfn), uintptr(unsafe.Pointer(arg)), 0))
 		if err == 0 {
-			pthread_detach(*thread)
+			call5(pthread_detachABI0, uintptr(*thread), 0, 0, 0, 0)
 			return 0
 		}
 		if err != int(syscall.EAGAIN) {
@@ -60,7 +60,7 @@ func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe
 		}
 		ts.Sec = 0
 		ts.Nsec = (tries + 1) * 1000 * 1000 // Milliseconds.
-		nanosleep(&ts, nil)
+		call5(nanosleepABI0, uintptr(unsafe.Pointer(&ts)), 0, 0, 0, 0)
 	}
 	return int(syscall.EAGAIN)
 }

--- a/internal/fakecgo/libcgo.go
+++ b/internal/fakecgo/libcgo.go
@@ -6,8 +6,11 @@
 package fakecgo
 
 type (
-	size_t         uintptr
-	sigset_t       [128]byte
+	size_t uintptr
+	// Sources:
+	// Darwin - https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/sys/_types.h#L74
+	// FreeBSD - https://github.com/DoctorWkt/xv6-freebsd/blob/d2a294c2a984baed27676068b15ed9a29b06ab6f/include/signal.h#L98C9-L98C21
+	sigset_t       [32]byte
 	pthread_attr_t [64]byte
 	pthread_t      int
 	pthread_key_t  uint64

--- a/internal/fakecgo/libcgo.go
+++ b/internal/fakecgo/libcgo.go
@@ -8,9 +8,10 @@ package fakecgo
 type (
 	size_t uintptr
 	// Sources:
-	// Darwin - https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/sys/_types.h#L74
-	// FreeBSD - https://github.com/DoctorWkt/xv6-freebsd/blob/d2a294c2a984baed27676068b15ed9a29b06ab6f/include/signal.h#L98C9-L98C21
-	sigset_t       [32]byte
+	// Darwin (32 bytes) - https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/sys/_types.h#L74
+	// FreeBSD (32 bytes) - https://github.com/DoctorWkt/xv6-freebsd/blob/d2a294c2a984baed27676068b15ed9a29b06ab6f/include/signal.h#L98C9-L98C21
+	// Linux (128 bytes) - https://github.com/torvalds/linux/blob/ab75170520d4964f3acf8bb1f91d34cbc650688e/arch/x86/include/asm/signal.h#L25
+	sigset_t       [128]byte
 	pthread_attr_t [64]byte
 	pthread_t      int
 	pthread_key_t  uint64

--- a/internal/fakecgo/symbols.go
+++ b/internal/fakecgo/symbols.go
@@ -18,84 +18,104 @@ func setg_trampoline(setg uintptr, G uintptr)
 // call5 takes fn the C function and 5 arguments and calls the function with those arguments
 func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
 
+//go:nosplit
 func malloc(size uintptr) unsafe.Pointer {
 	ret := call5(mallocABI0, uintptr(size), 0, 0, 0, 0)
 	// this indirection is to avoid go vet complaining about possible misuse of unsafe.Pointer
 	return *(*unsafe.Pointer)(unsafe.Pointer(&ret))
 }
 
+//go:nosplit
 func free(ptr unsafe.Pointer) {
 	call5(freeABI0, uintptr(ptr), 0, 0, 0, 0)
 }
 
+//go:nosplit
 func setenv(name *byte, value *byte, overwrite int32) int32 {
 	return int32(call5(setenvABI0, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), uintptr(overwrite), 0, 0))
 }
 
+//go:nosplit
 func unsetenv(name *byte) int32 {
 	return int32(call5(unsetenvABI0, uintptr(unsafe.Pointer(name)), 0, 0, 0, 0))
 }
 
+//go:nosplit
 func sigfillset(set *sigset_t) int32 {
 	return int32(call5(sigfillsetABI0, uintptr(unsafe.Pointer(set)), 0, 0, 0, 0))
 }
 
+//go:nosplit
 func nanosleep(ts *syscall.Timespec, rem *syscall.Timespec) int32 {
 	return int32(call5(nanosleepABI0, uintptr(unsafe.Pointer(ts)), uintptr(unsafe.Pointer(rem)), 0, 0, 0))
 }
 
+//go:nosplit
 func abort() {
 	call5(abortABI0, 0, 0, 0, 0, 0)
 }
 
+//go:nosplit
 func pthread_attr_init(attr *pthread_attr_t) int32 {
 	return int32(call5(pthread_attr_initABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
 }
 
+//go:nosplit
 func pthread_create(thread *pthread_t, attr *pthread_attr_t, start unsafe.Pointer, arg unsafe.Pointer) int32 {
 	return int32(call5(pthread_createABI0, uintptr(unsafe.Pointer(thread)), uintptr(unsafe.Pointer(attr)), uintptr(start), uintptr(arg), 0))
 }
 
+//go:nosplit
 func pthread_detach(thread pthread_t) int32 {
 	return int32(call5(pthread_detachABI0, uintptr(thread), 0, 0, 0, 0))
 }
 
+//go:nosplit
 func pthread_sigmask(how sighow, ign *sigset_t, oset *sigset_t) int32 {
 	return int32(call5(pthread_sigmaskABI0, uintptr(how), uintptr(unsafe.Pointer(ign)), uintptr(unsafe.Pointer(oset)), 0, 0))
 }
 
+//go:nosplit
 func pthread_self() pthread_t {
 	return pthread_t(call5(pthread_selfABI0, 0, 0, 0, 0, 0))
 }
 
+//go:nosplit
 func pthread_get_stacksize_np(thread pthread_t) size_t {
 	return size_t(call5(pthread_get_stacksize_npABI0, uintptr(thread), 0, 0, 0, 0))
 }
 
+//go:nosplit
 func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32 {
 	return int32(call5(pthread_attr_getstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(unsafe.Pointer(stacksize)), 0, 0, 0))
 }
 
+//go:nosplit
 func pthread_attr_setstacksize(attr *pthread_attr_t, size size_t) int32 {
 	return int32(call5(pthread_attr_setstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(size), 0, 0, 0))
 }
 
+//go:nosplit
 func pthread_attr_destroy(attr *pthread_attr_t) int32 {
 	return int32(call5(pthread_attr_destroyABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
 }
 
+//go:nosplit
 func pthread_mutex_lock(mutex *pthread_mutex_t) int32 {
 	return int32(call5(pthread_mutex_lockABI0, uintptr(unsafe.Pointer(mutex)), 0, 0, 0, 0))
 }
 
+//go:nosplit
 func pthread_mutex_unlock(mutex *pthread_mutex_t) int32 {
 	return int32(call5(pthread_mutex_unlockABI0, uintptr(unsafe.Pointer(mutex)), 0, 0, 0, 0))
 }
 
+//go:nosplit
 func pthread_cond_broadcast(cond *pthread_cond_t) int32 {
 	return int32(call5(pthread_cond_broadcastABI0, uintptr(unsafe.Pointer(cond)), 0, 0, 0, 0))
 }
 
+//go:nosplit
 func pthread_setspecific(key pthread_key_t, value unsafe.Pointer) int32 {
 	return int32(call5(pthread_setspecificABI0, uintptr(key), uintptr(value), 0, 0, 0))
 }


### PR DESCRIPTION
fakecgo runs on the system stack so we shouldn't ever split the stack.

I also updated the size of sigset_t to be the correct size based on the headers. This was needed to make it possible to build with inlining disabled when nosplit was added.

Fixes #287