### PR TITLE
.github/workflows: add -e for FreeBSD test script and skip NetBSD tests

### DIFF
--- a/.github/scripts/bsd_tests.sh
+++ b/.github/scripts/bsd_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Ebitengine Authors
@@ -69,11 +69,13 @@ env CGO_ENABLED=0 go test -gcflags="github.com/ebitengine/purego/internal/fakecg
 echo "=> go test CGO_ENABLED=1"
 env CGO_ENABLED=1 go test -shuffle=on -v -count=10 ./...
 
-echo "=> go test CGO_ENABLED=0 w/o optimization"
-env CGO_ENABLED=0 go test "-gcflags=all=-N -l" -v ./...
+# TODO: Enable this test again (#305).
+# echo "=> go test CGO_ENABLED=0 w/o optimization"
+# env CGO_ENABLED=0 go test "-gcflags=all=-N -l" -v ./...
 
-echo "=> go test CGO_ENABLED=1 w/o optimization"
-env CGO_ENABLED=1 go test "-gcflags=all=-N -l" -v ./...
+# TODO: Enable this test again (#305).
+# echo "=> go test CGO_ENABLED=1 w/o optimization"
+# env CGO_ENABLED=1 go test "-gcflags=all=-N -l" -v ./...
 
 if [ -z "$(go version | grep '^1.1')" ]; then
   echo "=> go test race"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
   bsd:
     strategy:
       matrix:
-        os: ['FreeBSD', 'NetBSD']
+        os: ['FreeBSD'] # TODO: Add 'NetBSD' again (#304)
         go: ['1.18.10', '1.19.13', '1.20.14', '1.21.13', '1.22.12', '1.23.7', '1.24.1']
         exclude:
           # there are no prebuilt download links for these versions of Go for NetBSD

--- a/README.md
+++ b/README.md
@@ -29,14 +29,13 @@ except for float arguments and return values.
 - **FreeBSD**: amd64, arm64
 - **Linux**: amd64, arm64
 - **macOS / iOS**: amd64, arm64
-- **NetBSD**: amd64, arm64
 - **Windows**: 386*, amd64, arm*, arm64
 
 `*` These architectures only support SyscallN and NewCallback
 
 ## Example
 
-The example below only showcases purego use for macOS, NetBSD and Linux. The other platforms require special handling which can
+The example below only showcases purego use for macOS, and Linux. The other platforms require special handling which can
 be seen in the complete example at [examples/libc](https://github.com/ebitengine/purego/tree/main/examples/libc) which supports Windows and FreeBSD.
 
 ```go


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
Without `-e` in the shebang `#!/bin/sh`, the script passed even some commands failed and then we missed some errors happened. This change adds `-e` to abort tests with an error code explicitly.

As #305 says, FreeBSD tests w/o optimization fails. This change skips the test temporarilly.

This change also retracts the support of NetBSD temporarily. Let's revert README again after #304 is fixed.

## What _type_ of issue is this addressing?
<!-- bug | feature | security -->

## What this PR does | solves
#304 and #305