### PR TITLE
examples/libc: reorder OSes in alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ except for float arguments and return values.
 
 ## Example
 
-The example below only showcases purego use for macOS, and Linux. The other platforms require special handling which can
-be seen in the complete example at [examples/libc](https://github.com/ebitengine/purego/tree/main/examples/libc) which supports Windows and FreeBSD.
+The example below only showcases purego use for macOS, Linux, and FreeBSD. The other platforms require special handling which can
+be seen in the complete example at [examples/libc](https://github.com/ebitengine/purego/tree/main/examples/libc) which supports Windows.
 
 ```go
 package main
@@ -52,10 +52,10 @@ func getSystemLibrary() string {
 	switch runtime.GOOS {
 	case "darwin":
 		return "/usr/lib/libSystem.B.dylib"
+	case "freebsd":
+		return "libc.so.7"
 	case "linux":
 		return "libc.so.6"
-	case "netbsd":
-		return "libc.so"
 	default:
 		panic(fmt.Errorf("GOOS=%s is not supported", runtime.GOOS))
 	}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ except for float arguments and return values.
 ## Example
 
 The example below only showcases purego use for macOS, FreeBSD, and Linux. The other platforms require special handling which can
-be seen in the complete example at [examples/libc](https://github.com/ebitengine/purego/tree/main/examples/libc) which supports Windows.
+be seen in the complete example at [examples/libc](https://github.com/ebitengine/purego/tree/main/examples/libc) which supports FreeBSD and Windows.
 
 ```go
 package main
@@ -52,8 +52,6 @@ func getSystemLibrary() string {
 	switch runtime.GOOS {
 	case "darwin":
 		return "/usr/lib/libSystem.B.dylib"
-	case "freebsd":
-		return "libc.so.7"
 	case "linux":
 		return "libc.so.6"
 	default:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ except for float arguments and return values.
 
 ## Example
 
-The example below only showcases purego use for macOS, Linux, and FreeBSD. The other platforms require special handling which can
+The example below only showcases purego use for macOS, FreeBSD, and Linux. The other platforms require special handling which can
 be seen in the complete example at [examples/libc](https://github.com/ebitengine/purego/tree/main/examples/libc) which supports Windows.
 
 ```go

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ except for float arguments and return values.
 
 ## Example
 
-The example below only showcases purego use for macOS, FreeBSD, and Linux. The other platforms require special handling which can
+The example below only showcases purego use for macOS and Linux. The other platforms require special handling which can
 be seen in the complete example at [examples/libc](https://github.com/ebitengine/purego/tree/main/examples/libc) which supports FreeBSD and Windows.
 
 ```go

--- a/examples/libc/main.go
+++ b/examples/libc/main.go
@@ -16,10 +16,10 @@ func getSystemLibrary() string {
 	switch runtime.GOOS {
 	case "darwin":
 		return "/usr/lib/libSystem.B.dylib"
-	case "linux":
-		return "libc.so.6"
 	case "freebsd":
 		return "libc.so.7"
+	case "linux":
+		return "libc.so.6"
 	case "netbsd":
 		return "libc.so"
 	case "windows":


### PR DESCRIPTION
This change also updates README by removing NetBSD and adding FreeBSD.

<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->

## What _type_ of issue is this addressing?
<!-- bug | feature | security -->

## What this PR does | solves
Just cleaning up codes and documents.