### PR TITLE
Allow uintptr in struct on amd64

### DIFF
--- a/struct_amd64.go
+++ b/struct_amd64.go
@@ -200,7 +200,7 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 				val |= f.Uint() << shift
 				shift += 32
 				class |= _INTEGER
-			case reflect.Uint64, reflect.Uint:
+			case reflect.Uint64, reflect.Uint, reflect.Uintptr:
 				val = f.Uint()
 				shift = 64
 				class = _INTEGER
@@ -245,7 +245,7 @@ func placeStack(v reflect.Value, addStack func(uintptr)) {
 			addStack(f.Pointer())
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			addStack(uintptr(f.Int()))
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 			addStack(uintptr(f.Uint()))
 		case reflect.Float32:
 			addStack(uintptr(math.Float32bits(float32(f.Float()))))

--- a/struct_test.go
+++ b/struct_test.go
@@ -463,6 +463,15 @@ func TestRegisterFunc_structArgs(t *testing.T) {
 			t.Fatalf("GoUint4Fn returned %d wanted %#x", ret, expected)
 		}
 	}
+	{
+		type OneLong struct{ a uintptr }
+		var TakeGoUintAndReturn func(a OneLong) uint64
+		purego.RegisterLibFunc(&TakeGoUintAndReturn, lib, "TakeGoUintAndReturn")
+		expected := uint64(7)
+		if ret := TakeGoUintAndReturn(OneLong{7}); ret != expected {
+			t.Fatalf("TakeGoUintAndReturn returned %+v wanted %+v", ret, expected)
+		}
+	}
 }
 
 func TestRegisterFunc_structReturns(t *testing.T) {

--- a/testdata/structtest/struct_test.c
+++ b/testdata/structtest/struct_test.c
@@ -348,3 +348,7 @@ struct GoUint4 {
 GoUint GoUint4(struct GoUint4 g) {
     return g.a + g.b + g.c + g.d;
 }
+
+GoUint TakeGoUintAndReturn(GoUint a) {
+    return a;
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->
Relates to https://github.com/hajimehoshi/ebiten/issues/3239

## What _type_ of issue is this addressing?
<!-- bug | feature | security -->
Fixes the bug that uintptr as the only field is not passed to uintptr field on amd64

## What this PR does | solves
<!-- Please be as descriptive as possible -->
