### PR TITLE
objc: bug fix: wrong implementation in encodeType for a struct

### DIFF
--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -461,7 +461,7 @@ func encodeType(typ reflect.Type, insidePtr bool) (string, error) {
 			}
 			encoding += tmp
 		}
-		encoding = encStructEnd
+		encoding += encStructEnd
 		return encoding, nil
 	case reflect.UnsafePointer:
 		return encUnsafePtr, nil


### PR DESCRIPTION
Updates #225

<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
This fixes a wrong implementation in encodeType for a struct type. A struct type is not used in the real world actually, but this should be a fix for the future.

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Updates #225