### PR TITLE
purego: use sync.Pool in syscall_syscall15X with wrapper

### DIFF
--- a/syscall_sysv.go
+++ b/syscall_sysv.go
@@ -14,14 +14,17 @@ import (
 
 var syscall15XABI0 uintptr
 
-//go:nosplit
 func syscall_syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 uintptr) (r1, r2, err uintptr) {
-	args := syscall15Args{
+	args := thePool.Get().(*syscall15Args)
+	defer thePool.Put(args)
+
+	*args = syscall15Args{
 		fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
 		a1, a2, a3, a4, a5, a6, a7, a8,
 		0,
 	}
-	runtime_cgocall(syscall15XABI0, unsafe.Pointer(&args))
+
+	runtime_cgocall(syscall15XABI0, unsafe.Pointer(args))
 	return args.a1, args.a2, 0
 }
 


### PR DESCRIPTION
This works around the stack growth issue in 05d8da4 while providing the same benefit. The syscall15Args does not escape to the heap for each purego call, reducing memory allocation rate **a lot** for ebitengine!

I am not sure why we need `go:nosplit` at the first place, though. Maybe that can just be removed and this optimization simplified.

<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
Reduces allocations on the hot path

## What _type_ of issue is this addressing?
Performance

## What this PR does | solves
reduced garbage collection