### PR TITLE
.github/workflows: add Go 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.18.x', '1.19.x', '1.20.x', '1.21.x', '1.22.x', '1.23.x', '1.24.x']
+        go: ['1.18.x', '1.19.x', '1.20.x', '1.21.x', '1.22.x', '1.23.x', '1.24.x', '1.25.x']
     name: Test with Go ${{ matrix.go }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
@@ -151,7 +151,7 @@ jobs:
     strategy:
       matrix:
         os: ['FreeBSD'] # TODO: Add 'NetBSD' again (#304)
-        go: ['1.18.10', '1.19.13', '1.20.14', '1.21.13', '1.22.12', '1.23.12', '1.24.6']
+        go: ['1.18.10', '1.19.13', '1.20.14', '1.21.13', '1.22.12', '1.23.12', '1.24.6', '1.25.0']
         exclude:
           # there are no prebuilt download links for these versions of Go for NetBSD
           - os: NetBSD


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
As Go 1.25 has been released, add this version for PureGo tests.

## What _type_ of issue is this addressing?
n/a

## What this PR does | solves
n/a
