### PR TITLE
test linux/arm64 on a native GHA runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
           env CGO_ENABLED=1 GOARCH=386 go test -shuffle=on -v -count=10 ./...
 
       - name: go test (Linux 386)
-        if: ${{ runner.os == 'Linux' && !endsWith(matrix.os, '-arm') }}
+        if: ${{ runner.os == 'Linux' && runner.arch != 'ARM64' }}
         run: |
            sudo apt-get update
            sudo apt-get install gcc-multilib


### PR DESCRIPTION
GitHub Actions supports native Linux ARM64 runners. We can use them instead of running QEMU on Intel.

While here, move the loong64-related steps into their own job. This makes the yml simpler and the actions execution around 1 minute faster.