### PR TITLE
struct: fix bool field placement at non-zero offsets

### DIFF
--- a/struct_amd64.go
+++ b/struct_amd64.go
@@ -165,7 +165,7 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 				place(f)
 			case reflect.Bool:
 				if f.Bool() {
-					val |= 1
+					val |= 1 << shift
 				}
 				shift += 8
 				class |= _INTEGER

--- a/struct_arm64.go
+++ b/struct_arm64.go
@@ -123,7 +123,7 @@ func placeRegisters(v reflect.Value, addFloat func(uintptr), addInt func(uintptr
 				place(f)
 			case reflect.Bool:
 				if f.Bool() {
-					val |= 1
+					val |= 1 << shift
 				}
 				shift += 8
 				class |= _INT

--- a/struct_loong64.go
+++ b/struct_loong64.go
@@ -104,7 +104,7 @@ func placeRegisters(v reflect.Value, addFloat func(uintptr), addInt func(uintptr
 				place(f)
 			case reflect.Bool:
 				if f.Bool() {
-					val |= 1
+					val |= 1 << shift
 				}
 				shift += 8
 				class |= _INT

--- a/struct_test.go
+++ b/struct_test.go
@@ -472,6 +472,20 @@ func TestRegisterFunc_structArgs(t *testing.T) {
 			t.Fatalf("TakeGoUintAndReturn returned %+v wanted %+v", ret, expected)
 		}
 	}
+	{
+		type FloatAndBool struct {
+			x float32
+			y bool
+		}
+		var FloatAndBoolFn func(FloatAndBool) int32
+		purego.RegisterLibFunc(&FloatAndBoolFn, lib, "FloatAndBool")
+		if ret := FloatAndBoolFn(FloatAndBool{x: 12345.0, y: true}); ret != 1 {
+			t.Fatalf("FloatAndBool(y: true) = %d, want 1", ret)
+		}
+		if ret := FloatAndBoolFn(FloatAndBool{x: 12345.0, y: false}); ret != 0 {
+			t.Fatalf("FloatAndBool(y: false) = %d, want 0", ret)
+		}
+	}
 }
 
 func TestRegisterFunc_structReturns(t *testing.T) {

--- a/testdata/structtest/struct_test.c
+++ b/testdata/structtest/struct_test.c
@@ -352,3 +352,12 @@ GoUint GoUint4(struct GoUint4 g) {
 GoUint TakeGoUintAndReturn(GoUint a) {
     return a;
 }
+
+struct FloatAndBool {
+    float value;
+    _Bool has_value;
+};
+
+int FloatAndBool(struct FloatAndBool f) {
+    return f.has_value;
+}


### PR DESCRIPTION
Bool fields were incorrectly placed at bit 0 regardless of their offset within the struct. This caused incorrect marshalling when bool fields appeared after other fields.

The fix properly shifts the bool value by the current bit offset, ensuring it's placed at the correct position in the packed struct data.

Adds regression test with FloatAndBool struct to verify the fix.

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->

Closes #350 

## What _type_ of issue is this addressing?
bug

## What this PR does
Fixes offsets of bool fields.
