### PR TITLE
testdata: add clang-format configuration and apply formatting

### DIFF
--- a/testdata/.clang-format
+++ b/testdata/.clang-format
@@ -1,0 +1,14 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 0
+SortIncludes: Never
+SpaceAfterCStyleCast: true
+AllowShortBlocksOnASingleLine: Always
+AllowShortFunctionsOnASingleLine: None
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: true
+  AlignFunctionPointers: true
+  PadOperators: true

--- a/testdata/abitest/abi_test.c
+++ b/testdata/abitest/abi_test.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 
-uint32_t stack_uint8_t(uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e, uint32_t f, uint32_t g, uint32_t h, uint8_t i, uint8_t j, uint32_t k ) {
+uint32_t stack_uint8_t(uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e, uint32_t f, uint32_t g, uint32_t h, uint8_t i, uint8_t j, uint32_t k) {
     assert(i == 1);
     assert(j == 2);
     assert(k == 1024);
@@ -20,7 +20,7 @@ uint32_t reg_uint8_t(uint8_t a, uint8_t b, uint32_t c) {
     return a | b | c;
 }
 
-uint32_t stack_string(uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e, uint32_t f, uint32_t g, uint32_t h, const char * i) {
+uint32_t stack_string(uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e, uint32_t f, uint32_t g, uint32_t h, const char *i) {
     assert(i != 0);
     assert(strcmp(i, "test") == 0);
     return a | b | c | d | e | f | g | h;

--- a/testdata/libcbtest/callback_test.c
+++ b/testdata/libcbtest/callback_test.c
@@ -8,6 +8,6 @@ typedef int (*callback)(const char *, int);
 int callCallback(const void *fp, const char *s) {
     // If the callback corrupts FP, this local variable on the stack will have incorrect value.
     int sentinel = 10101;
-    ((callback)(fp))(s, strlen(s));
+    ((callback) (fp))(s, strlen(s));
     return sentinel;
 }

--- a/testdata/structtest/struct_test.c
+++ b/testdata/structtest/struct_test.c
@@ -4,7 +4,7 @@
 #include "stdint.h"
 
 #if defined(__x86_64__) || defined(__aarch64__)
-typedef int64_t GoInt;
+typedef int64_t  GoInt;
 typedef uint64_t GoUint;
 #endif
 
@@ -30,7 +30,7 @@ unsigned long EmptyEmptyWithReg(unsigned int x, struct EmptyEmpty e, unsigned in
 
 // GreaterThan16Bytes is 24 bytes on 64 bit systems
 struct GreaterThan16Bytes {
-   long  *x, *y, *z;
+    long *x, *y, *z;
 };
 
 // GreaterThan16Bytes is a basic test for structs bigger than 16 bytes
@@ -41,7 +41,7 @@ unsigned long GreaterThan16Bytes(struct GreaterThan16Bytes g) {
 // AfterRegisters tests to make sure that structs placed on the stack work properly
 unsigned long AfterRegisters(long a, long b, long c, long d, long e, long f, long g, long h, struct GreaterThan16Bytes bytes) {
     long registers = a + b + c + d + e + f + g + h;
-    long stack =  *bytes.x + *bytes.y + *bytes.z;
+    long stack = *bytes.x + *bytes.y + *bytes.z;
     if (registers != stack) {
         return 0xbadbad;
     }
@@ -57,8 +57,8 @@ unsigned long BeforeRegisters(struct GreaterThan16Bytes bytes, long a, long b) {
 
 struct GreaterThan16BytesStruct {
     struct {
-        long  *x, *y, *z;
-    } a ;
+        long *x, *y, *z;
+    } a;
 };
 
 unsigned long GreaterThan16BytesStruct(struct GreaterThan16BytesStruct g) {
@@ -173,7 +173,7 @@ struct UnsignedChar4Bytes {
 };
 
 unsigned int UnsignedChar4Bytes(struct UnsignedChar4Bytes b) {
-    return (((int)b.a)<<24) | (((int)b.b)<<16) | (((int)b.c)<<8) | (((int)b.d)<<0);
+    return (((int) b.a) << 24) | (((int) b.b) << 16) | (((int) b.c) << 8) | (((int) b.d) << 0);
 }
 
 struct UnsignedChar4BytesStruct {
@@ -192,7 +192,7 @@ struct UnsignedChar4BytesStruct {
 };
 
 unsigned int UnsignedChar4BytesStruct(struct UnsignedChar4BytesStruct b) {
-    return (((int)b.x.a)<<24) | (((int)b.y.b)<<16) | (((int)b.z.c)<<8) | (((int)b.w.d)<<0);
+    return (((int) b.x.a) << 24) | (((int) b.y.b) << 16) | (((int) b.z.c) << 8) | (((int) b.w.d) << 0);
 }
 
 struct Short {
@@ -200,7 +200,7 @@ struct Short {
 };
 
 unsigned long Short(struct Short s) {
-    return (long)s.a << 48 | (long)s.b << 32 | (long)s.c << 16 | (long)s.d << 0;
+    return (long) s.a << 48 | (long) s.b << 32 | (long) s.c << 16 | (long) s.d << 0;
 }
 
 struct Int {
@@ -208,7 +208,7 @@ struct Int {
 };
 
 unsigned long Int(struct Int i) {
-    return (long)i.a << 32 | (long)i.b << 0;
+    return (long) i.a << 32 | (long) i.b << 0;
 }
 
 struct Long {
@@ -224,7 +224,7 @@ struct Char8Bytes {
 };
 
 int Char8Bytes(struct Char8Bytes b) {
-    return (int)b.a + (int)b.b + (int)b.c + (int)b.d + (int)b.e + (int)b.f + (int)b.g + (int)b.h;
+    return (int) b.a + (int) b.b + (int) b.c + (int) b.d + (int) b.e + (int) b.f + (int) b.g + (int) b.h;
 }
 
 struct Odd {
@@ -232,20 +232,20 @@ struct Odd {
 };
 
 int Odd(struct Odd o) {
-    return (int)o.a + (int)o.b + (int)o.c;
+    return (int) o.a + (int) o.b + (int) o.c;
 }
 
 struct Char2Short1 {
-    unsigned char a, b;
+    unsigned char  a, b;
     unsigned short c;
 };
 
 int Char2Short1s(struct Char2Short1 s) {
-    return (int)s.a + (int)s.b + (int)s.c;
+    return (int) s.a + (int) s.b + (int) s.c;
 }
 
 struct SignedChar2Short1 {
-    signed char a, b;
+    signed char  a, b;
     signed short c;
 };
 
@@ -258,7 +258,7 @@ struct Array4UnsignedChars {
 };
 
 unsigned int Array4UnsignedChars(struct Array4UnsignedChars a) {
-    return (((int)a.a[0])<<24) | (((int)a.a[1])<<16) | (((int)a.a[2])<<8) | (((int)a.a[3])<<0);
+    return (((int) a.a[0]) << 24) | (((int) a.a[1]) << 16) | (((int) a.a[2]) << 8) | (((int) a.a[3]) << 0);
 }
 
 struct Array3UnsignedChar {
@@ -266,7 +266,7 @@ struct Array3UnsignedChar {
 };
 
 unsigned int Array3UnsignedChars(struct Array3UnsignedChar a) {
-    return (((int)a.a[0])<<24) | (((int)a.a[1])<<16) | (((int)a.a[2])<<8) | 0xef;
+    return (((int) a.a[0]) << 24) | (((int) a.a[1]) << 16) | (((int) a.a[2]) << 8) | 0xef;
 }
 
 struct Array2UnsignedShort {
@@ -274,7 +274,7 @@ struct Array2UnsignedShort {
 };
 
 unsigned int Array2UnsignedShorts(struct Array2UnsignedShort a) {
-    return (((int)a.a[0])<<16) | (((int)a.a[1])<<0);
+    return (((int) a.a[0]) << 16) | (((int) a.a[1]) << 0);
 }
 
 struct Array4Chars {
@@ -282,7 +282,7 @@ struct Array4Chars {
 };
 
 int Array4Chars(struct Array4Chars a) {
-    return (int)a.a[0] + (int)a.a[1] + (int)a.a[2] + (int)a.a[3];
+    return (int) a.a[0] + (int) a.a[1] + (int) a.a[2] + (int) a.a[3];
 }
 
 struct Array2Short {
@@ -290,7 +290,7 @@ struct Array2Short {
 };
 
 int Array2Shorts(struct Array2Short a) {
-    return (int)a.a[0] + (int)a.a[1];
+    return (int) a.a[0] + (int) a.a[1];
 }
 
 struct Array3Short {
@@ -298,7 +298,7 @@ struct Array3Short {
 };
 
 int Array3Shorts(struct Array3Short a) {
-    return (int)a.a[0] + (int)a.a[1] + (int)a.a[2];
+    return (int) a.a[0] + (int) a.a[1] + (int) a.a[2];
 }
 
 struct BoolStruct {
@@ -321,16 +321,20 @@ float BoolFloat(struct BoolFloat s) {
 }
 
 struct Content {
-      struct { double x, y; } point;
-      struct { double width, height; } size;
+    struct {
+        double x, y;
+    } point;
+    struct {
+        double width, height;
+    } size;
 };
 
 unsigned long InitWithContentRect(int *win, struct Content c, int style, int backing, _Bool flag) {
-  if (win == 0)
-      return 0xBAD;
-  if (!flag)
-      return 0xF1A6; // FLAG
-  return (unsigned long)(c.point.x + c.point.y + c.size.width + c.size.height) / (style - backing);
+    if (win == 0)
+        return 0xBAD;
+    if (!flag)
+        return 0xF1A6; // FLAG
+    return (unsigned long) (c.point.x + c.point.y + c.size.width + c.size.height) / (style - backing);
 }
 
 struct GoInt4 {

--- a/testdata/structtest/structreturn_test.c
+++ b/testdata/structtest/structreturn_test.c
@@ -3,17 +3,23 @@
 
 #include <stdint.h>
 
-struct Empty{};
+struct Empty {};
 
 struct Empty ReturnEmpty() {
     struct Empty e = {};
     return e;
 }
 
-struct StructInStruct{
-    struct{ int16_t a; } a;
-    struct{ int16_t b; } b;
-    struct{ int16_t c; } c;
+struct StructInStruct {
+    struct {
+        int16_t a;
+    } a;
+    struct {
+        int16_t b;
+    } b;
+    struct {
+        int16_t c;
+    } c;
 };
 
 struct StructInStruct ReturnStructInStruct(int16_t a, int16_t b, int16_t c) {
@@ -21,7 +27,7 @@ struct StructInStruct ReturnStructInStruct(int16_t a, int16_t b, int16_t c) {
     return e;
 }
 
-struct ThreeShorts{
+struct ThreeShorts {
     int16_t a, b, c;
 };
 
@@ -30,7 +36,7 @@ struct ThreeShorts ReturnThreeShorts(int16_t a, int16_t b, int16_t c) {
     return e;
 }
 
-struct FourShorts{
+struct FourShorts {
     int16_t a, b, c, d;
 };
 
@@ -39,7 +45,7 @@ struct FourShorts ReturnFourShorts(int16_t a, int16_t b, int16_t c, int16_t d) {
     return e;
 }
 
-struct OneLong{
+struct OneLong {
     int64_t a;
 };
 
@@ -48,7 +54,7 @@ struct OneLong ReturnOneLong(int64_t a) {
     return e;
 }
 
-struct TwoLongs{
+struct TwoLongs {
     int64_t a, b;
 };
 
@@ -57,7 +63,7 @@ struct TwoLongs ReturnTwoLongs(int64_t a, int64_t b) {
     return e;
 }
 
-struct ThreeLongs{
+struct ThreeLongs {
     int64_t a, b, c;
 };
 
@@ -66,20 +72,20 @@ struct ThreeLongs ReturnThreeLongs(int64_t a, int64_t b, int64_t c) {
     return e;
 }
 
-struct OneFloat{
+struct OneFloat {
     float a;
 };
 
-struct TwoFloats{
+struct TwoFloats {
     float a, b;
 };
 
 struct TwoFloats ReturnTwoFloats(float a, float b) {
-    struct TwoFloats e = {a-b, a*b};
+    struct TwoFloats e = {a - b, a * b};
     return e;
 }
 
-struct ThreeFloats{
+struct ThreeFloats {
     float a, b, c;
 };
 
@@ -93,7 +99,7 @@ struct OneFloat ReturnOneFloat(float a) {
     return e;
 }
 
-struct OneDouble{
+struct OneDouble {
     double a;
 };
 
@@ -102,7 +108,7 @@ struct OneDouble ReturnOneDouble(double a) {
     return e;
 }
 
-struct TwoDoubles{
+struct TwoDoubles {
     double a, b;
 };
 
@@ -111,7 +117,7 @@ struct TwoDoubles ReturnTwoDoubles(double a, double b) {
     return e;
 }
 
-struct ThreeDoubles{
+struct ThreeDoubles {
     double a, b, c;
 };
 
@@ -120,7 +126,7 @@ struct ThreeDoubles ReturnThreeDoubles(double a, double b, double c) {
     return e;
 }
 
-struct FourDoubles{
+struct FourDoubles {
     double a, b, c, d;
 };
 
@@ -129,7 +135,7 @@ struct FourDoubles ReturnFourDoubles(double a, double b, double c, double d) {
     return e;
 }
 
-struct FourDoublesInternal{
+struct FourDoublesInternal {
     struct {
         double a, b;
     } f;
@@ -139,11 +145,11 @@ struct FourDoublesInternal{
 };
 
 struct FourDoublesInternal ReturnFourDoublesInternal(double a, double b, double c, double d) {
-    struct FourDoublesInternal e = { {a, b}, {c, d} };
+    struct FourDoublesInternal e = {{a, b}, {c, d}};
     return e;
 }
 
-struct FiveDoubles{
+struct FiveDoubles {
     double a, b, c, d, e;
 };
 
@@ -152,8 +158,8 @@ struct FiveDoubles ReturnFiveDoubles(double a, double b, double c, double d, dou
     return s;
 }
 
-struct OneFloatOneDouble{
-    float a;
+struct OneFloatOneDouble {
+    float  a;
     double b;
 };
 
@@ -162,9 +168,9 @@ struct OneFloatOneDouble ReturnOneFloatOneDouble(float a, double b) {
     return e;
 }
 
-struct OneDoubleOneFloat{
+struct OneDoubleOneFloat {
     double a;
-    float b;
+    float  b;
 };
 
 struct OneDoubleOneFloat ReturnOneDoubleOneFloat(double a, float b) {
@@ -172,7 +178,7 @@ struct OneDoubleOneFloat ReturnOneDoubleOneFloat(double a, float b) {
     return e;
 }
 
-struct Unaligned1{
+struct Unaligned1 {
     int8_t  a;
     int16_t b;
     int64_t c;
@@ -183,9 +189,9 @@ struct Unaligned1 ReturnUnaligned1(int8_t a, int16_t b, int64_t c) {
     return e;
 }
 
-struct Mixed1{
-     float a;
-     int32_t b;
+struct Mixed1 {
+    float   a;
+    int32_t b;
 };
 
 struct Mixed1 ReturnMixed1(float a, int32_t b) {
@@ -193,11 +199,11 @@ struct Mixed1 ReturnMixed1(float a, int32_t b) {
     return e;
 }
 
-struct Mixed2{
-     float a;
-     int32_t b;
-     float c;
-     int32_t d;
+struct Mixed2 {
+    float   a;
+    int32_t b;
+    float   c;
+    int32_t d;
 };
 
 struct Mixed2 ReturnMixed2(float a, int32_t b, float c, int32_t d) {
@@ -205,10 +211,10 @@ struct Mixed2 ReturnMixed2(float a, int32_t b, float c, int32_t d) {
     return e;
 }
 
-struct Mixed3{
-     float a;
-     uint32_t b;
-     double c;
+struct Mixed3 {
+    float    a;
+    uint32_t b;
+    double   c;
 };
 
 struct Mixed3 ReturnMixed3(float a, uint32_t b, double c) {
@@ -216,10 +222,10 @@ struct Mixed3 ReturnMixed3(float a, uint32_t b, double c) {
     return s;
 }
 
-struct Mixed4{
-     double a;
-     uint32_t b;
-     float c;
+struct Mixed4 {
+    double   a;
+    uint32_t b;
+    float    c;
 };
 
 struct Mixed4 ReturnMixed4(double a, uint32_t b, float c) {
@@ -227,9 +233,9 @@ struct Mixed4 ReturnMixed4(double a, uint32_t b, float c) {
     return s;
 }
 
-struct Ptr1{
-     int64_t *a;
-     void *b;
+struct Ptr1 {
+    int64_t *a;
+    void    *b;
 };
 
 struct Ptr1 ReturnPtr1(int64_t *a, void *b) {


### PR DESCRIPTION
Adds .clang-format configuration with LLVM-based style settings and applies consistent formatting to all C test files. No functional changes, only code style improvements for better readability and consistency.