### PR TITLE
purego: add dlfcn simulation on windows (#366)

### DIFF
--- a/dlfcn_windows.go
+++ b/dlfcn_windows.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
+
+package purego
+
+import (
+	"golang.org/x/sys/windows"
+	"path/filepath"
+)
+
+const (
+	RTLD_DEFAULT = 0x00000 // Pseudo-handle for dlsym so search for any loaded symbol
+	RTLD_LAZY    = 0x00001 // Relocations are performed at an implementation-dependent time.
+	RTLD_NOW     = 0x00002 // Relocations are performed when the object is loaded.
+	RTLD_LOCAL   = 0x00000 // All symbols are not made available for relocation processing by other modules.
+	RTLD_GLOBAL  = 0x00100 // All symbols are available for relocation processing of other modules.
+)
+
+// Dlopen examines the dynamic library or bundle file specified by path.
+//
+// The mode was ignored on Windows.
+func Dlopen(path string, mode int) (uintptr, error) {
+	if len(path) == 0 {
+		return getSelfModuleHandle(true), nil
+	}
+	handle, err := windows.LoadLibrary(filepath.ToSlash(path))
+	if err != nil {
+		return 0, err
+	}
+	return uintptr(handle), nil
+}
+
+// Dlsym takes a "handle" of a dynamic library returned by Dlopen and the symbol name.
+func Dlsym(handle uintptr, name string) (uintptr, error) {
+	if handle == RTLD_DEFAULT {
+		handle = getSelfModuleHandle(false)
+	}
+	return windows.GetProcAddress(windows.Handle(handle), name)
+}
+
+// Dlclose decrements the reference count on the dynamic library handle.
+func Dlclose(handle uintptr) error {
+	return windows.FreeLibrary(windows.Handle(handle))
+}
+
+func getSelfModuleHandle(incrementRefCount bool) uintptr {
+	var handle windows.Handle
+	if incrementRefCount {
+		windows.GetModuleHandleEx(0, nil, &handle)
+	} else {
+		windows.GetModuleHandleEx(windows.GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, nil, &handle)
+	}
+	return uintptr(handle)
+}

--- a/dlfcn_windows_test.go
+++ b/dlfcn_windows_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023 The Ebitengine Authors
+
+package purego_test
+
+import (
+	"github.com/ebitengine/purego"
+	"testing"
+	"unsafe"
+)
+
+func TestMessageBox(t *testing.T) {
+	user32, err := purego.Dlopen("user32.dll", purego.RTLD_NOW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer purego.Dlclose(user32)
+
+	symbol, err := purego.Dlsym(user32, "MessageBoxA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var messageBox func(hwnd unsafe.Pointer, text, caption string, flag uint32)
+	purego.RegisterFunc(&messageBox, symbol)
+
+	messageBox(nil, "message", "information", 0)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/ebitengine/purego
 
-go 1.18
+go 1.24.0
+
+toolchain go1.24.7
+
+require golang.org/x/sys v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
# What issue is this addressing?
Closes #366 

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
add dlfcn functions(Dlopen, Dlsym and Dlclose) simulation on windows.
