### PR TITLE
.github/workflows: update actions versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
 
@@ -143,9 +143,9 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - name: Set up the prerequisites
@@ -182,7 +182,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run in FreeBSD
         if: matrix.os == 'FreeBSD'
         uses: vmactions/freebsd-vm@v1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
n/a

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
At least, Go 1.19 failed to be downloaded with the old action. Update the actions.
