### PR TITLE
Setup golangci-lint configuration with dedicated lint workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# ensure that line endings for Windows builds are properly formatted
+# see https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#how-to-use
+# at "Multiple OS Example" section
+*.go text eol=lf

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,63 @@
+name: Lint
+
+on:
+ push: 
+   branches:
+    - main
+ pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS combinations
+          - {os: macos-latest, CGO_ENABLED: "0", GOOS: darwin, GOARCH: amd64}
+          - {os: macos-latest, CGO_ENABLED: "1", GOOS: darwin, GOARCH: amd64}
+          - {os: macos-latest, CGO_ENABLED: "0", GOOS: darwin, GOARCH: arm64}
+          - {os: macos-latest, CGO_ENABLED: "1", GOOS: darwin, GOARCH: arm64}
+          
+          # Linux combinations
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: amd64}
+          - {os: ubuntu-latest, CGO_ENABLED: "1", GOOS: linux, GOARCH: amd64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: arm64}
+          
+          # FreeBSD/NetBSD combinations sans CGO_ENABLED=1
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: freebsd, GOARCH: amd64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: freebsd, GOARCH: arm64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: netbsd, GOARCH: amd64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: netbsd, GOARCH: arm64}
+          
+          # Windows combinations
+          - {os: windows-latest, CGO_ENABLED: "0", GOOS: windows, GOARCH: amd64}
+          - {os: windows-latest, CGO_ENABLED: "1", GOOS: windows, GOARCH: amd64}
+          - {os: windows-latest, CGO_ENABLED: "0", GOOS: windows, GOARCH: arm64}
+          - {os: windows-latest, CGO_ENABLED: "0", GOOS: windows, GOARCH: 386}
+    permissions:
+      contents: read
+      pull-requests: read
+    name: lint (${{ matrix.GOOS }}/${{ matrix.GOARCH }}/cgo=${{ matrix.CGO_ENABLED }})
+    runs-on: ${{ matrix.os }}
+    env:
+      CGO_ENABLED: "${{ matrix.CGO_ENABLED }}"
+      GOARCH: ${{ matrix.GOARCH }}
+      GOOS: ${{ matrix.GOOS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version-file: go.mod
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,39 @@
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      # Section configuration to compare against.
+      # Section names are case-insensitive and may contain parameters in ().
+      # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`.
+      # If `custom-order` is `true`, it follows the order of `sections` option.
+      # Default: ["standard", "default"]
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/ebitengine/purego) # Custom section: groups all imports with the specified Prefix.
+
+issues:
+  # Show all issues
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  # Use standard set of linters as default
+  default: standard
+  
+  # Disable linters that are not suitable for this low-level library
+  disable:
+    - errcheck
+    - gosec         # Reports "unsafe" operations which are intentional in this library
+    - ineffassign
+    - staticcheck
+    - unconvert     # Removes unnecessary type conversions
+    - unused
+
+run:  
+  # Minimum Go version to support
+  go: "1.18"
+
+version: "2"

--- a/internal/fakecgo/freebsd.go
+++ b/internal/fakecgo/freebsd.go
@@ -23,5 +23,7 @@ import _ "unsafe" // for go:linkname
 //go:cgo_export_dynamic environ
 //go:cgo_export_dynamic __progname
 
-var _environ uintptr
-var _progname uintptr
+var (
+	_environ  uintptr
+	_progname uintptr
+)

--- a/internal/fakecgo/go_linux.go
+++ b/internal/fakecgo/go_linux.go
@@ -16,7 +16,7 @@ func _cgo_sys_thread_start(ts *ThreadStart) {
 	var size size_t
 	var err int
 
-	//fprintf(stderr, "runtime/cgo: _cgo_sys_thread_start: fn=%p, g=%p\n", ts->fn, ts->g); // debug
+	// fprintf(stderr, "runtime/cgo: _cgo_sys_thread_start: fn=%p, g=%p\n", ts->fn, ts->g); // debug
 	sigfillset(&ign)
 	pthread_sigmask(SIG_SETMASK, &ign, &oset)
 

--- a/objc/objc_block_darwin_test.go
+++ b/objc/objc_block_darwin_test.go
@@ -17,7 +17,7 @@ func ExampleNewBlock() {
 		panic(err)
 	}
 
-	var count = 0
+	count := 0
 	block := objc.NewBlock(
 		func(block objc.Block, line objc.ID, stop *bool) {
 			count++


### PR DESCRIPTION
# What issue is this addressing?
Setup golangci-lint configuration integrated into test workflow

## What _type_ of issue is this addressing?
This is providing some commonly used linters in the golang community to help maintainers improve the quality of the project they produce. See https://golangci-lint.run if you want to know more about this.

## What this PR does | solves
Fixes #375
