### PR TITLE
fakecgo: don't overwrite the caller stack on arm64 trampolines

### DIFF
--- a/internal/fakecgo/trampolines_arm64.s
+++ b/internal/fakecgo/trampolines_arm64.s
@@ -7,7 +7,8 @@
 #include "go_asm.h"
 #include "abi_arm64.h"
 
-// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
+// These trampolines map the gcc ABI to Go ABIInternal and then calls into the Go equivalent functions.
+// Note that C arguments are passed in R0-R7, which matches Go ABIInternal for the first eight arguments.
 
 TEXT x_cgo_init_trampoline(SB), NOSPLIT, $0-0
 	MOVD ·x_cgo_init_call(SB), R26


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
Updates https://github.com/ebitengine/purego/issues/343

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
amd64 and arm64 assembly trampolines moved from stack arguments to register arguments in #73. This means that we don't need to store the registers on the stack anymore. Note that doing so might even lead to some nasty bugs, as we are writing on stack slots that haven't been allocated in the function frame, potentially corrupting the caller stack.
