### PR TITLE
purego: bug fix: the register number in a generator file was wrong

### DIFF
--- a/wincallback.go
+++ b/wincallback.go
@@ -91,7 +91,7 @@ func genasmLoong64() {
 TEXT callbackasm(SB),NOSPLIT|NOFRAME,$0
 `)
 	for i := 0; i < maxCallback; i++ {
-		fmt.Fprintf(&buf, "\tMOVV\t$%d, R13\n", i)
+		fmt.Fprintf(&buf, "\tMOVV\t$%d, R12\n", i)
 		buf.WriteString("\tJMP\tcallbackasm1(SB)\n")
 	}
 	if err := os.WriteFile("zcallback_loong64.s", buf.Bytes(), 0644); err != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
n/a

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The register number in a generator file wincallback.go and a generated file zcallback_loong64.s were not synchronized correctly. This was introduced in the original PR for loong64: 045732660bc4b298c428c8d98716c8eec4266289

The generated file by `go generate` and the current files are correctly synchronized after this change.

