### PR TITLE
Simplify and better document callbackasm for riscv64

### DIFF
--- a/wincallback.go
+++ b/wincallback.go
@@ -112,7 +112,7 @@ func genasmRiscv64() {
 // Since Go 1.26, MOV instructions with immediate values lower than or equal to 32
 // are encoded in 2 bytes rather than 4 bytes, which breaks the assumption that each
 // callback entry is 8 bytes long. Therefore, for callback indices less than or equal to 32,
-// we add a PCALIGN directive to align the next instruction to an 8-byte boundary.
+// add a PCALIGN directive to align the next instruction to an 8-byte boundary.
 // The MOV instruction loads X7 with the callback index, and the
 // JMP instruction branches to callbackasm1.
 // callbackasm1 takes the callback index from X7 and

--- a/zcallback_riscv64.s
+++ b/zcallback_riscv64.s
@@ -7,7 +7,7 @@
 // Since Go 1.26, MOV instructions with immediate values lower than or equal to 32
 // are encoded in 2 bytes rather than 4 bytes, which breaks the assumption that each
 // callback entry is 8 bytes long. Therefore, for callback indices less than or equal to 32,
-// we add a PCALIGN directive to align the next instruction to an 8-byte boundary.
+// add a PCALIGN directive to align the next instruction to an 8-byte boundary.
 // The MOV instruction loads X7 with the callback index, and the
 // JMP instruction branches to callbackasm1.
 // callbackasm1 takes the callback index from X7 and


### PR DESCRIPTION
Since Go 1.26, MOV instructions with immediate values lower than or equal to 32 are encoded in 2 bytes rather than 4 bytes (see https://github.com/golang/go/issues/47560), which breaks the assumption that each callback entry in `callbackasm` is 8 bytes long. Therefore, for callback indices less than or equal to 32, we add a PCALIGN directive to align the next instruction to an 8-byte boundary.

This was already done in #385. This PR documents why PCALIGN are necessary in `callbackasm` and also remove all unnecessary PCALIGN instructions.