### PR TITLE
fakecgo: use C ABI in amd64 trampolines

### DIFF
--- a/internal/fakecgo/trampolines_amd64.s
+++ b/internal/fakecgo/trampolines_amd64.s
@@ -16,7 +16,7 @@ C Calling convention cdecl used here (we only need integer args):
 6. arg: R9
 We don't need floats with these functions -> AX=0
 return value will be in AX
-temporary registers are R10 and R11
+temporary register is R11
 */
 #include "textflag.h"
 #include "go_asm.h"


### PR DESCRIPTION
# What issue is this addressing?
N/A

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

Go might expect (in the future) that `x_cgo_init_trampoline` trampolines and friends honor the C calling convention, i.e. callee-saved (aka non-volatile) registers shouldn't be clobbered by the called function.

It is more future proof, safer, and more standard, to use R11 as a temporary register.

