### PR TITLE
.github/workflows: update QEMU packages to 10.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+env:
+  QEMU_VERSION: "10.2.1+ds-1"
+
 jobs:
   test:
     strategy:
@@ -136,9 +139,10 @@ jobs:
            # Install QEMU 10.x from Debian trixie. Ubuntu 24.04 ships QEMU 8.2
            # which has a bug where inter-thread signal delivery (tgkill) hangs,
            # causing TestSetuidEtc to deadlock.
-           wget -q http://ftp.debian.org/debian/pool/main/q/qemu/qemu-user_10.0.7+ds-0+deb13u1+b1_arm64.deb -O /tmp/qemu-user.deb
-           wget -q http://ftp.debian.org/debian/pool/main/q/qemu/qemu-user-binfmt_10.0.7+ds-0+deb13u1+b1_arm64.deb -O /tmp/qemu-user-binfmt.deb
+           wget -q https://ftp.debian.org/debian/pool/main/q/qemu/qemu-user_${QEMU_VERSION}_arm64.deb -O /tmp/qemu-user.deb
+           wget -q https://ftp.debian.org/debian/pool/main/q/qemu/qemu-user-binfmt_${QEMU_VERSION}_arm64.deb -O /tmp/qemu-user-binfmt.deb
            sudo dpkg --force-depends -i /tmp/qemu-user.deb /tmp/qemu-user-binfmt.deb
+           sudo apt-get -f install -y
 
            # Create symlink for the dynamic linker that QEMU expects
            sudo ln -sf /usr/arm-linux-gnueabihf/lib/ld-linux-armhf.so.3 /lib/ld-linux.so.3
@@ -194,8 +198,8 @@ jobs:
           # Install QEMU 10.x from Debian trixie. Ubuntu 24.04 ships QEMU 8.2
           # which has a bug where inter-thread signal delivery (tgkill) hangs,
           # causing TestSetuidEtc to deadlock.
-          wget -q http://ftp.debian.org/debian/pool/main/q/qemu/qemu-user_10.0.7+ds-0+deb13u1+b1_amd64.deb -O /tmp/qemu-user.deb
-          wget -q http://ftp.debian.org/debian/pool/main/q/qemu/qemu-user-binfmt_10.0.7+ds-0+deb13u1+b1_amd64.deb -O /tmp/qemu-user-binfmt.deb
+          wget -q https://ftp.debian.org/debian/pool/main/q/qemu/qemu-user_${QEMU_VERSION}_amd64.deb -O /tmp/qemu-user.deb
+          wget -q https://ftp.debian.org/debian/pool/main/q/qemu/qemu-user-binfmt_${QEMU_VERSION}_amd64.deb -O /tmp/qemu-user-binfmt.deb
           sudo dpkg --force-depends -i /tmp/qemu-user.deb /tmp/qemu-user-binfmt.deb
           sudo apt-get -f install -y
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
n/a

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
This fixes the test failures on installing QEMU.

The old version (10.0.7) was removed from the Debian repository, causing CI to fail with wget exit code 8.
