### PR TITLE
purego: remove pooling of syscall

### DIFF
--- a/func.go
+++ b/func.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"reflect"
 	"runtime"
-	"sync"
 	"unsafe"
 
 	"github.com/ebitengine/purego/internal/strings"
@@ -21,10 +20,6 @@ const (
 	align8ByteMask = 7 // Mask for 8-byte alignment: (val + 7) &^ 7
 	align8ByteSize = 8 // 8-byte alignment boundary
 )
-
-var thePool = sync.Pool{New: func() any {
-	return new(syscallArgs)
-}}
 
 // RegisterLibFunc is a wrapper around RegisterFunc that uses the C function returned from Dlsym(handle, name).
 // It panics if it can't find the name symbol.
@@ -323,13 +318,12 @@ func RegisterFunc(fptr any, cfn uintptr) {
 		var syscall *syscallArgs
 		if runtime.GOOS == "windows" && runtime.GOARCH != "arm64" {
 			// Windows amd64, 386, and arm use syscall.SyscallN.
-			syscall = thePool.Get().(*syscallArgs)
+			syscall = &syscallArgs{}
 			syscall.a1, syscall.a2, _ = syscall_syscallN(cfn, sysargs[:numStack]...)
 			syscall.f1 = syscall.a2 // on amd64 a2 stores the float return. On 32bit platforms floats aren't support
 		} else {
 			syscall = syscall_SyscallN(cfn, sysargs[:], floats[:], arm64_r8)
 		}
-		defer thePool.Put(syscall)
 		if ty.NumOut() == 0 {
 			return nil
 		}

--- a/func_test.go
+++ b/func_test.go
@@ -36,7 +36,7 @@ func getSystemLibrary() (string, error) {
 	}
 }
 
-func TestRegisterFunc_(t *testing.T) {
+func TestRegisterFunc_ConcurrentPointerReturn(t *testing.T) {
 	library, err := getSystemLibrary()
 	if err != nil {
 		t.Fatalf("couldn't get system library: %s", err)

--- a/func_test.go
+++ b/func_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"unsafe"
 
@@ -33,6 +34,40 @@ func getSystemLibrary() (string, error) {
 	default:
 		return "", fmt.Errorf("GOOS=%s is not supported", runtime.GOOS)
 	}
+}
+
+func TestRegisterFunc_(t *testing.T) {
+	library, err := getSystemLibrary()
+	if err != nil {
+		t.Fatalf("couldn't get system library: %s", err)
+	}
+	libc, err := load.OpenLibrary(library)
+	if err != nil {
+		t.Fatalf("failed to dlopen: %s", err)
+	}
+
+	var alloc func(uint64) *byte
+	var free func(*byte)
+	purego.RegisterLibFunc(&alloc, libc, "malloc")
+	purego.RegisterLibFunc(&free, libc, "free")
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < runtime.NumCPU(); i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 400_000; j++ {
+				ptr := alloc(5)
+				if ptr == nil {
+					continue
+				}
+				free(ptr)
+			}
+		}(i)
+	}
+
+	wg.Wait()
 }
 
 func TestRegisterFunc(t *testing.T) {

--- a/syscall.go
+++ b/syscall.go
@@ -22,8 +22,7 @@ type syscallArgs struct {
 }
 
 func syscall_SyscallN(fn uintptr, sysargs []uintptr, floats []uintptr, r8 uintptr) *syscallArgs {
-	s := thePool.Get().(*syscallArgs)
-	*s = syscallArgs{
+	s := &syscallArgs{
 		fn: fn,
 		a1: sysargs[0], a2: sysargs[1], a3: sysargs[2], a4: sysargs[3],
 		a5: sysargs[4], a6: sysargs[5], a7: sysargs[6], a8: sysargs[7],
@@ -79,6 +78,5 @@ func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 	var floats [maxArgs]uintptr
 	copy(floats[:], tmp[:])
 	s := syscall_SyscallN(fn, tmp[:], floats[:], 0)
-	defer thePool.Put(s)
 	return s.a1, s.a2, s.a3
 }

--- a/syscall_32bit.go
+++ b/syscall_32bit.go
@@ -22,8 +22,7 @@ type syscallArgs struct {
 }
 
 func syscall_SyscallN(fn uintptr, sysargs []uintptr, floats []uintptr, r8 uintptr) *syscallArgs {
-	s := thePool.Get().(*syscallArgs)
-	*s = syscallArgs{
+	s := &syscallArgs{
 		fn: fn,
 		a1: sysargs[0], a2: sysargs[1], a3: sysargs[2], a4: sysargs[3],
 		a5: sysargs[4], a6: sysargs[5], a7: sysargs[6], a8: sysargs[7],
@@ -81,6 +80,5 @@ func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 	var floats [16]uintptr
 	copy(floats[:], tmp[:16])
 	s := syscall_SyscallN(fn, tmp[:], floats[:], 0)
-	defer thePool.Put(s)
 	return s.a1, s.a2, s.a3
 }

--- a/syscall_ppc64le.go
+++ b/syscall_ppc64le.go
@@ -20,8 +20,7 @@ type syscallArgs struct {
 }
 
 func syscall_SyscallN(fn uintptr, sysargs []uintptr, floats []uintptr, r8 uintptr) *syscallArgs {
-	s := thePool.Get().(*syscallArgs)
-	*s = syscallArgs{
+	s := &syscallArgs{
 		fn: fn,
 		a1: sysargs[0], a2: sysargs[1], a3: sysargs[2], a4: sysargs[3],
 		a5: sysargs[4], a6: sysargs[5], a7: sysargs[6], a8: sysargs[7],
@@ -67,6 +66,5 @@ func SyscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 	var floats [maxArgs]uintptr
 	copy(floats[:], tmp[:])
 	s := syscall_SyscallN(fn, tmp[:], floats[:], 0)
-	defer thePool.Put(s)
 	return s.a1, s.a2, s.a3
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->
Closes #451

## What _type_ of issue is this addressing?
<!-- bug | feature | security -->
Bug

## What this PR does | solves
<!-- Please be as descriptive as possible -->
This removes the pool which was occasionally causing issues. Unfortunately this does increase the memory cost of each call
