### PR TITLE
internal/fakecgo: remove runtime.load_g references

### DIFF
--- a/internal/fakecgo/asm_arm.s
+++ b/internal/fakecgo/asm_arm.s
@@ -32,8 +32,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	MOVD F14, (13*4+8*7)(R13)
 	MOVD F15, (13*4+8*8)(R13)
 
-	BL runtime·load_g(SB)
-
 	// We set up the arguments to cgocallback when saving registers above.
 	BL runtime·cgocallback(SB)
 

--- a/internal/fakecgo/asm_arm64.s
+++ b/internal/fakecgo/asm_arm64.s
@@ -25,7 +25,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	STP (R29, R30), (8*22)(RSP)
 
 	// Initialize Go ABI environment
-	BL runtime·load_g(SB)
 	BL runtime·cgocallback(SB)
 
 	RESTORE_R19_TO_R28(8*4)

--- a/internal/fakecgo/asm_loong64.s
+++ b/internal/fakecgo/asm_loong64.s
@@ -27,8 +27,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	MOVV R1, (22*8)(R3)
 
 	// Initialize Go ABI environment
-	JAL runtime·load_g(SB)
-
 	JAL runtime·cgocallback(SB)
 
 	RESTORE_R22_TO_R31((4*8))

--- a/internal/fakecgo/asm_ppc64le.s
+++ b/internal/fakecgo/asm_ppc64le.s
@@ -50,9 +50,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	// Initialize R0 to 0 as expected by Go
 	MOVD $0, R0
 
-	// Load the current g.
-	BL runtime·load_g(SB)
-
 	// Set up arguments for cgocallback
 	MOVD R3, FIXED_FRAME+0(R1) // fn unsafe.Pointer
 	MOVD R4, FIXED_FRAME+8(R1) // a unsafe.Pointer

--- a/internal/fakecgo/asm_riscv64.s
+++ b/internal/fakecgo/asm_riscv64.s
@@ -25,7 +25,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	SAVE_FPR((8*17))
 
 	// Initialize Go ABI environment
-	CALL runtime·load_g(SB)
 	CALL runtime·cgocallback(SB)
 
 	RESTORE_GPR((8*4))

--- a/internal/fakecgo/asm_s390x.s
+++ b/internal/fakecgo/asm_s390x.s
@@ -27,9 +27,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	FMOVD F14, 80(R15)
 	FMOVD F15, 88(R15)
 
-	// Initialize Go ABI environment.
-	BL runtime·load_g(SB)
-
 	MOVD R2, 8(R15)  // fn unsafe.Pointer
 	MOVD R3, 16(R15) // a unsafe.Pointer
 

--- a/internal/fakecgo/trampolines_ppc64le.s
+++ b/internal/fakecgo/trampolines_ppc64le.s
@@ -47,15 +47,19 @@ TEXT x_cgo_bindm_trampoline(SB), NOSPLIT, $0-0
 
 // func setg_trampoline(setg uintptr, g uintptr)
 TEXT ·setg_trampoline(SB), NOSPLIT, $16-16
-	MOVD R31, 8(R1) // save R31 (load_g clobbers it)
+	MOVD R31, 8(R1) // save R31
 
 	MOVD setg+0(FP), R12
 	MOVD newg+8(FP), R3
 
+	MOVD R3, 16(R1) // save newg before call
+
 	MOVD R12, CTR
 	CALL CTR
 
-	CALL runtime·load_g(SB)
+	// Assign g directly instead of calling runtime·load_g
+	// setg_gcc has already stored newg into TLS; put it in the g register too.
+	MOVD 16(R1), g
 
 	MOVD 8(R1), R31
 	XOR  R0, R0, R0


### PR DESCRIPTION
## Summary

Go 1.27 ([`golang/go@aee6009`](https://github.com/golang/go/commit/aee6009ba5e1d71948b03ac0458fbc99e3a14ace)) enforces stricter `checklinkname` for assembly symbols. `runtime.load_g` is now `//go:linknamestd` (std-only), causing linker errors for non-std packages that reference it:

```
link: main: invalid reference to runtime.load_g
```

## Changes

**crosscall2 (6 architectures: arm, arm64, loong64, ppc64le, riscv64, s390x):**
Remove the `load_g` call — `cgocallback` already calls `load_g` internally, so the explicit call is unnecessary. The amd64 and 386 variants already did not call it.

**setg_trampoline (ppc64le):**
Replace the `load_g` call with a direct assignment to the `g` register from the saved `newg` argument, since `setg_gcc` has already stored it into TLS.

## Status

This resolves the `runtime.load_g` linker error. The `runtime.cgocallback` reference remains and will need an upstream Go change or the `-ldflags='-checklinkname=0'` workaround until resolved upstream.