### PR TITLE
internal/fakecgo: gate go_freebsd.go to amd64/arm64

### DIFF
--- a/internal/fakecgo/go_freebsd.go
+++ b/internal/fakecgo/go_freebsd.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !cgo
+//go:build !cgo && (amd64 || arm64)
 
 package fakecgo
 


### PR DESCRIPTION
# What issue is this addressing?

Closes #463

## What _type_ of issue is this addressing?

bug

## What this PR does | solves

In pure-Go mode (`CGO_ENABLED=0`, the `internal/fakecgo` path), `freebsd/386` and `freebsd/arm` silently compiled, even though FreeBSD is only a supported tier on amd64/arm64 — it is not built in CI and not run-tested.

NetBSD already guards against this: `internal/fakecgo/go_netbsd.go` is build-tagged `//go:build !cgo && (amd64 || arm64)`, so `netbsd/386` and `netbsd/arm` fail to build with `undefined: threadentry`. Its FreeBSD counterpart `go_freebsd.go` was tagged just `//go:build !cgo`, with no architecture gate. The two files are byte-identical except for a NetBSD-specific signal-stack reset in `threadentry` (an OS-specific difference, not arch-specific), so the missing gate on FreeBSD is an oversight, not a deliberate 32-bit-FreeBSD capability.

This PR mirrors NetBSD by adding the same gate to `go_freebsd.go` — and only that file, exactly as NetBSD gates only `go_netbsd.go`:

```diff
-//go:build !cgo
+//go:build !cgo && (amd64 || arm64)
```

### Result

- `freebsd/386` and `freebsd/arm` now refuse to build under `CGO_ENABLED=0`, with the same `undefined: threadentry` error as `netbsd/386`, instead of shipping an untested binary.
- `freebsd/amd64` and `freebsd/arm64` still build.
- The cgo path is unaffected: with `CGO_ENABLED=1` the entire `internal/fakecgo` package is excluded (every file is `!cgo`), and the documented cgo fallback still supports `freebsd/386` (it selects `cgo.go` + `syscall_32bit.go`). Only the untested pure-Go 32-bit build is removed — exactly how `netbsd/386` already behaves.

### Verification

Cross-compiled every `go tool dist list` target with `CGO_ENABLED=0 go build ./...` (FreeBSD/NetBSD with `-gcflags="github.com/ebitengine/purego/internal/fakecgo=-std"`) before and after the change; the only delta is `freebsd/386` and `freebsd/arm` moving from build to fail. `go test ./...` passes on the host, and `gofmt -s` is clean.

---

_Authored by Claude (Anthropic's Claude Code), on behalf of @hajimehoshi._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
