### PR TITLE
fakecgo: restrict freebsd/netbsd build constraints to amd64/arm64

### DIFF
--- a/internal/fakecgo/go_libinit.go
+++ b/internal/fakecgo/go_libinit.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build !cgo && (darwin || freebsd || linux || netbsd)
+//go:build !cgo && (darwin || linux || ((freebsd || netbsd) && (amd64 || arm64)))
 
 package fakecgo
 

--- a/internal/fakecgo/go_setenv.go
+++ b/internal/fakecgo/go_setenv.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build !cgo && (darwin || freebsd || linux || netbsd)
+//go:build !cgo && (darwin || linux || ((freebsd || netbsd) && (amd64 || arm64)))
 
 package fakecgo
 

--- a/internal/fakecgo/go_util.go
+++ b/internal/fakecgo/go_util.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 
-//go:build !cgo && (darwin || freebsd || linux || netbsd)
+//go:build !cgo && (darwin || linux || ((freebsd || netbsd) && (amd64 || arm64)))
 
 package fakecgo
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

This PR restricts the `freebsd` and `netbsd` build constraints in fakecgo's shared files (go_util.go, go_setenv.go, go_libinit.go) to `amd64`/`arm64`, matching the arch constraints already present in the OS-specific go_freebsd.go and go_netbsd.go files. This prevents build failures on unsupported architectures (e.g. `freebsd/386`), where the shared files would otherwise compile but reference symbols like `_cgo_sys_thread_start` that are never defined.
