### PR TITLE
purego: support structs on loong64

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Tier 2 platforms are supported by PureGo on a best-effort basis. Critical bugs o
 
 - **Android**: 386<sup>1,3</sup>, arm<sup>1,3</sup>
 - **FreeBSD**: amd64<sup>3,4</sup>, arm64<sup>3,4</sup>
-- **Linux**: 386<sup>3</sup>, arm<sup>3</sup>, loong64<sup>3</sup>, ppc64le<sup>3</sup>, riscv64<sup>3</sup>, s390x<sup>3, 5</sup>
+- **Linux**: 386<sup>3</sup>, arm<sup>3</sup>, loong64<sup>2</sup>, ppc64le<sup>2</sup>, riscv64<sup>2</sup>, s390x<sup>2, 5</sup>
 - **NetBSD**: amd64<sup>3,4</sup>, arm64<sup>3,4</sup>
 - **Windows**: 386<sup>3,6</sup>, arm<sup>3,6,7</sup>
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Tier 2 platforms are supported by PureGo on a best-effort basis. Critical bugs o
 
 - **Android**: 386<sup>1,3</sup>, arm<sup>1,3</sup>
 - **FreeBSD**: amd64<sup>3,4</sup>, arm64<sup>3,4</sup>
-- **Linux**: 386<sup>3</sup>, arm<sup>3</sup>, loong64<sup>2</sup>, ppc64le<sup>2</sup>, riscv64<sup>2</sup>, s390x<sup>2, 5</sup>
+- **Linux**: 386<sup>3</sup>, arm<sup>3</sup>, loong64<sup>2</sup>, ppc64le<sup>3</sup>, riscv64<sup>3</sup>, s390x<sup>3, 5</sup>
 - **NetBSD**: amd64<sup>3,4</sup>, arm64<sup>3,4</sup>
 - **Windows**: 386<sup>3,6</sup>, arm<sup>3,6,7</sup>
 

--- a/func.go
+++ b/func.go
@@ -504,9 +504,9 @@ func checkStructFieldsSupported(ty reflect.Type) {
 // a C function is unsupported on the current platform.
 func ensureStructSupported() {
 	switch runtime.GOARCH {
-	case "amd64", "arm64", "loong64", "ppc64le", "riscv64", "s390x":
+	case "amd64", "arm64", "loong64":
 	default:
-		panic("purego: struct arguments/returns are only supported on amd64, arm64, loong64, ppc64le, riscv64, and s390x")
+		panic("purego: struct arguments/returns are only supported on amd64, arm64, and loong64")
 	}
 	switch runtime.GOOS {
 	case "android", "darwin", "ios", "linux", "windows":

--- a/func.go
+++ b/func.go
@@ -500,14 +500,32 @@ func checkStructFieldsSupported(ty reflect.Type) {
 	}
 }
 
+// ensureStructSupported panics if passing or returning structs through a call to
+// a C function is unsupported on the current platform.
 func ensureStructSupported() {
-	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
-		panic("purego: struct arguments/returns are only supported on amd64 and arm64")
+	switch runtime.GOARCH {
+	case "amd64", "arm64", "loong64", "ppc64le", "riscv64", "s390x":
+	default:
+		panic("purego: struct arguments/returns are only supported on amd64, arm64, loong64, ppc64le, riscv64, and s390x")
 	}
 	switch runtime.GOOS {
 	case "android", "darwin", "ios", "linux", "windows":
 	default:
 		panic("purego: struct arguments/returns are only supported on android, darwin, ios, linux, and windows")
+	}
+}
+
+// ensureCallbackStructSupported panics if passing or returning structs through a
+// callback is unsupported on the current platform. Callbacks support structs on
+// fewer architectures than a direct call to a C function.
+func ensureCallbackStructSupported() {
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+		panic("purego: struct arguments/returns in callbacks are only supported on amd64 and arm64")
+	}
+	switch runtime.GOOS {
+	case "android", "darwin", "ios", "linux", "windows":
+	default:
+		panic("purego: struct arguments/returns in callbacks are only supported on android, darwin, ios, linux, and windows")
 	}
 }
 

--- a/struct_loong64.go
+++ b/struct_loong64.go
@@ -22,7 +22,7 @@ type loong64Leaf struct {
 func loong64Flatten(t reflect.Type, base uintptr, leaves *[]loong64Leaf) {
 	switch t.Kind() {
 	case reflect.Struct:
-		for i := 0; i < t.NumField(); i++ {
+		for i := range t.NumField() {
 			f := t.Field(i)
 			if f.Name == "_" {
 				// Blank fields are explicit padding to match the C layout, not
@@ -33,7 +33,7 @@ func loong64Flatten(t reflect.Type, base uintptr, leaves *[]loong64Leaf) {
 		}
 	case reflect.Array:
 		elem := t.Elem()
-		for i := 0; i < t.Len(); i++ {
+		for i := range t.Len() {
 			loong64Flatten(elem, base+uintptr(i)*elem.Size(), leaves)
 		}
 	default:
@@ -79,7 +79,10 @@ func getStruct(outType reflect.Type, syscall syscallArgs) reflect.Value {
 	}
 	if outSize > 16 {
 		// Returned indirectly through a pointer in the first integer register.
-		return reflect.NewAt(outType, *(*unsafe.Pointer)(unsafe.Pointer(&syscall.a1))).Elem()
+		// Read it from a local copy so the address does not alias the pooled
+		// syscallArgs.
+		a1 := syscall.a1
+		return reflect.NewAt(outType, *(*unsafe.Pointer)(unsafe.Pointer(&a1))).Elem()
 	}
 
 	var buf [16]byte
@@ -90,18 +93,18 @@ func getStruct(outType reflect.Type, syscall syscallArgs) reflect.Value {
 		var fi, ii int
 		for _, l := range leaves {
 			dst := unsafe.Add(base, l.offset)
-			if l.isFloat {
-				r := floatRegs[fi]
-				fi++
-				if l.kind == reflect.Float32 {
-					// A single-precision value is NaN-boxed in the register.
-					*(*uint32)(dst) = uint32(r)
-				} else {
-					*(*uint64)(dst) = uint64(r)
-				}
-			} else {
+			if !l.isFloat {
 				loong64StoreInt(dst, l.size, intRegs[ii])
 				ii++
+				continue
+			}
+			r := floatRegs[fi]
+			fi++
+			if l.kind == reflect.Float32 {
+				// A single-precision value is NaN-boxed in the register.
+				*(*uint32)(dst) = uint32(r)
+			} else {
+				*(*uint64)(dst) = uint64(r)
 			}
 		}
 	} else {

--- a/struct_loong64.go
+++ b/struct_loong64.go
@@ -79,10 +79,7 @@ func getStruct(outType reflect.Type, syscall syscallArgs) reflect.Value {
 	}
 	if outSize > 16 {
 		// Returned indirectly through a pointer in the first integer register.
-		// Read it from a local copy so the address does not alias the pooled
-		// syscallArgs.
-		a1 := syscall.a1
-		return reflect.NewAt(outType, *(*unsafe.Pointer)(unsafe.Pointer(&a1))).Elem()
+		return reflect.NewAt(outType, *(*unsafe.Pointer)(unsafe.Pointer(&syscall.a1))).Elem()
 	}
 
 	var buf [16]byte

--- a/struct_loong64.go
+++ b/struct_loong64.go
@@ -8,18 +8,18 @@ import (
 	"unsafe"
 )
 
-// loongLeaf is a scalar member of an aggregate after flattening nested structs
+// loong64Leaf is a scalar member of an aggregate after flattening nested structs
 // and arrays. offset is the byte offset of the member within the aggregate.
-type loongLeaf struct {
+type loong64Leaf struct {
 	isFloat bool
 	kind    reflect.Kind
 	offset  uintptr
 	size    uintptr
 }
 
-// loongFlatten appends the scalar leaves of t to leaves, offsetting each member
+// loong64Flatten appends the scalar leaves of t to leaves, offsetting each member
 // by base. Nested structs and arrays are expanded into their members.
-func loongFlatten(t reflect.Type, base uintptr, leaves *[]loongLeaf) {
+func loong64Flatten(t reflect.Type, base uintptr, leaves *[]loong64Leaf) {
 	switch t.Kind() {
 	case reflect.Struct:
 		for i := 0; i < t.NumField(); i++ {
@@ -29,16 +29,16 @@ func loongFlatten(t reflect.Type, base uintptr, leaves *[]loongLeaf) {
 				// members that the calling convention counts.
 				continue
 			}
-			loongFlatten(f.Type, base+f.Offset, leaves)
+			loong64Flatten(f.Type, base+f.Offset, leaves)
 		}
 	case reflect.Array:
 		elem := t.Elem()
 		for i := 0; i < t.Len(); i++ {
-			loongFlatten(elem, base+uintptr(i)*elem.Size(), leaves)
+			loong64Flatten(elem, base+uintptr(i)*elem.Size(), leaves)
 		}
 	default:
 		k := t.Kind()
-		*leaves = append(*leaves, loongLeaf{
+		*leaves = append(*leaves, loong64Leaf{
 			isFloat: k == reflect.Float32 || k == reflect.Float64,
 			kind:    k,
 			offset:  base,
@@ -47,13 +47,13 @@ func loongFlatten(t reflect.Type, base uintptr, leaves *[]loongLeaf) {
 	}
 }
 
-// loongClassify flattens t and reports whether it is passed and returned through
+// loong64Classify flattens t and reports whether it is passed and returned through
 // the floating-point calling convention. Under the LoongArch hard-float ABI an
 // aggregate uses FP registers only when, after flattening, it has one or two
 // floating-point members and nothing else, or exactly one floating-point member
 // together with one integer member.
-func loongClassify(t reflect.Type) (leaves []loongLeaf, useFP bool) {
-	loongFlatten(t, 0, &leaves)
+func loong64Classify(t reflect.Type) (leaves []loong64Leaf, useFP bool) {
+	loong64Flatten(t, 0, &leaves)
 	var floats, ints int
 	for _, l := range leaves {
 		if l.isFloat {
@@ -84,7 +84,7 @@ func getStruct(outType reflect.Type, syscall syscallArgs) reflect.Value {
 
 	var buf [16]byte
 	base := unsafe.Pointer(&buf[0])
-	if leaves, useFP := loongClassify(outType); useFP {
+	if leaves, useFP := loong64Classify(outType); useFP {
 		floatRegs := [2]uintptr{syscall.f1, syscall.f2}
 		intRegs := [2]uintptr{syscall.a1, syscall.a2}
 		var fi, ii int
@@ -100,7 +100,7 @@ func getStruct(outType reflect.Type, syscall syscallArgs) reflect.Value {
 					*(*uint64)(dst) = uint64(r)
 				}
 			} else {
-				loongStoreInt(dst, l.size, intRegs[ii])
+				loong64StoreInt(dst, l.size, intRegs[ii])
 				ii++
 			}
 		}
@@ -113,7 +113,7 @@ func getStruct(outType reflect.Type, syscall syscallArgs) reflect.Value {
 	return reflect.NewAt(outType, base).Elem()
 }
 
-func loongStoreInt(dst unsafe.Pointer, size uintptr, r uintptr) {
+func loong64StoreInt(dst unsafe.Pointer, size uintptr, r uintptr) {
 	switch size {
 	case 1:
 		*(*uint8)(dst) = uint8(r)
@@ -145,7 +145,7 @@ func addStruct(v reflect.Value, numInts, numFloats, numStack *int, addInt, addFl
 		keepAlive = append(keepAlive, tmp.Interface())
 	}
 
-	if leaves, useFP := loongClassify(v.Type()); useFP {
+	if leaves, useFP := loong64Classify(v.Type()); useFP {
 		for _, l := range leaves {
 			src := unsafe.Add(ptr, l.offset)
 			switch {
@@ -155,7 +155,7 @@ func addStruct(v reflect.Value, numInts, numFloats, numStack *int, addInt, addFl
 			case l.isFloat:
 				addFloat(uintptr(*(*uint64)(src)))
 			default:
-				addInt(loongLoadInt(src, l))
+				addInt(loong64LoadInt(src, l))
 			}
 		}
 		return keepAlive
@@ -171,9 +171,9 @@ func addStruct(v reflect.Value, numInts, numFloats, numStack *int, addInt, addFl
 	return keepAlive
 }
 
-// loongLoadInt reads an integer leaf into a register value, sign-extending
+// loong64LoadInt reads an integer leaf into a register value, sign-extending
 // signed members and zero-extending the rest.
-func loongLoadInt(src unsafe.Pointer, l loongLeaf) uintptr {
+func loong64LoadInt(src unsafe.Pointer, l loong64Leaf) uintptr {
 	switch l.kind {
 	case reflect.Int8:
 		return uintptr(int64(*(*int8)(src)))

--- a/struct_loong64.go
+++ b/struct_loong64.go
@@ -24,6 +24,11 @@ func loongFlatten(t reflect.Type, base uintptr, leaves *[]loongLeaf) {
 	case reflect.Struct:
 		for i := 0; i < t.NumField(); i++ {
 			f := t.Field(i)
+			if f.Name == "_" {
+				// Blank fields are explicit padding to match the C layout, not
+				// members that the calling convention counts.
+				continue
+			}
 			loongFlatten(f.Type, base+f.Offset, leaves)
 		}
 	case reflect.Array:

--- a/struct_loong64.go
+++ b/struct_loong64.go
@@ -4,177 +4,188 @@
 package purego
 
 import (
-	"math"
 	"reflect"
 	"unsafe"
 )
 
-func getStruct(outType reflect.Type, syscall syscallArgs) (v reflect.Value) {
-	outSize := outType.Size()
-	switch {
-	case outSize == 0:
-		return reflect.New(outType).Elem()
-	case outSize <= 8:
-		r1 := syscall.a1
-		if isAllFloats, numFields := isAllSameFloat(outType); isAllFloats {
-			r1 = syscall.f1
-			if numFields == 2 {
-				r1 = syscall.f2<<32 | syscall.f1
-			}
+// loongLeaf is a scalar member of an aggregate after flattening nested structs
+// and arrays. offset is the byte offset of the member within the aggregate.
+type loongLeaf struct {
+	isFloat bool
+	kind    reflect.Kind
+	offset  uintptr
+	size    uintptr
+}
+
+// loongFlatten appends the scalar leaves of t to leaves, offsetting each member
+// by base. Nested structs and arrays are expanded into their members.
+func loongFlatten(t reflect.Type, base uintptr, leaves *[]loongLeaf) {
+	switch t.Kind() {
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			loongFlatten(f.Type, base+f.Offset, leaves)
 		}
-		return reflect.NewAt(outType, unsafe.Pointer(&struct{ a uintptr }{r1})).Elem()
-	case outSize <= 16:
-		r1, r2 := syscall.a1, syscall.a2
-		if isAllFloats, numFields := isAllSameFloat(outType); isAllFloats {
-			switch numFields {
-			case 4:
-				r1 = syscall.f2<<32 | syscall.f1
-				r2 = syscall.f4<<32 | syscall.f3
-			case 3:
-				r1 = syscall.f2<<32 | syscall.f1
-				r2 = syscall.f3
-			case 2:
-				r1 = syscall.f1
-				r2 = syscall.f2
-			default:
-				panic("not reached")
-			}
+	case reflect.Array:
+		elem := t.Elem()
+		for i := 0; i < t.Len(); i++ {
+			loongFlatten(elem, base+uintptr(i)*elem.Size(), leaves)
 		}
-		return reflect.NewAt(outType, unsafe.Pointer(&struct{ a, b uintptr }{r1, r2})).Elem()
 	default:
-		// create struct from the Go pointer created above
-		// weird pointer dereference to circumvent go vet
-		return reflect.NewAt(outType, *(*unsafe.Pointer)(unsafe.Pointer(&syscall.a1))).Elem()
+		k := t.Kind()
+		*leaves = append(*leaves, loongLeaf{
+			isFloat: k == reflect.Float32 || k == reflect.Float64,
+			kind:    k,
+			offset:  base,
+			size:    t.Size(),
+		})
 	}
 }
 
-const (
-	_NO_CLASS = 0b00
-	_FLOAT    = 0b01
-	_INT      = 0b11
-)
+// loongClassify flattens t and reports whether it is passed and returned through
+// the floating-point calling convention. Under the LoongArch hard-float ABI an
+// aggregate uses FP registers only when, after flattening, it has one or two
+// floating-point members and nothing else, or exactly one floating-point member
+// together with one integer member.
+func loongClassify(t reflect.Type) (leaves []loongLeaf, useFP bool) {
+	loongFlatten(t, 0, &leaves)
+	var floats, ints int
+	for _, l := range leaves {
+		if l.isFloat {
+			floats++
+		} else {
+			ints++
+		}
+	}
+	switch {
+	case ints == 0 && (floats == 1 || floats == 2):
+		return leaves, true
+	case ints == 1 && floats == 1:
+		return leaves, true
+	default:
+		return leaves, false
+	}
+}
+
+func getStruct(outType reflect.Type, syscall syscallArgs) reflect.Value {
+	outSize := outType.Size()
+	if outSize == 0 {
+		return reflect.New(outType).Elem()
+	}
+	if outSize > 16 {
+		// Returned indirectly through a pointer in the first integer register.
+		return reflect.NewAt(outType, *(*unsafe.Pointer)(unsafe.Pointer(&syscall.a1))).Elem()
+	}
+
+	var buf [16]byte
+	base := unsafe.Pointer(&buf[0])
+	if leaves, useFP := loongClassify(outType); useFP {
+		floatRegs := [2]uintptr{syscall.f1, syscall.f2}
+		intRegs := [2]uintptr{syscall.a1, syscall.a2}
+		var fi, ii int
+		for _, l := range leaves {
+			dst := unsafe.Add(base, l.offset)
+			if l.isFloat {
+				r := floatRegs[fi]
+				fi++
+				if l.kind == reflect.Float32 {
+					// A single-precision value is NaN-boxed in the register.
+					*(*uint32)(dst) = uint32(r)
+				} else {
+					*(*uint64)(dst) = uint64(r)
+				}
+			} else {
+				loongStoreInt(dst, l.size, intRegs[ii])
+				ii++
+			}
+		}
+	} else {
+		*(*uintptr)(base) = syscall.a1
+		if outSize > 8 {
+			*(*uintptr)(unsafe.Add(base, 8)) = syscall.a2
+		}
+	}
+	return reflect.NewAt(outType, base).Elem()
+}
+
+func loongStoreInt(dst unsafe.Pointer, size uintptr, r uintptr) {
+	switch size {
+	case 1:
+		*(*uint8)(dst) = uint8(r)
+	case 2:
+		*(*uint16)(dst) = uint16(r)
+	case 4:
+		*(*uint32)(dst) = uint32(r)
+	default:
+		*(*uint64)(dst) = uint64(r)
+	}
+}
 
 func addStruct(v reflect.Value, numInts, numFloats, numStack *int, addInt, addFloat, addStack func(uintptr), keepAlive []any) []any {
-	if v.Type().Size() == 0 {
+	size := v.Type().Size()
+	if size == 0 {
+		return keepAlive
+	}
+	if size > 16 {
+		return placeStack(v, keepAlive, addInt)
+	}
+
+	var ptr unsafe.Pointer
+	if v.CanAddr() {
+		ptr = v.Addr().UnsafePointer()
+	} else {
+		tmp := reflect.New(v.Type())
+		tmp.Elem().Set(v)
+		ptr = tmp.UnsafePointer()
+		keepAlive = append(keepAlive, tmp.Interface())
+	}
+
+	if leaves, useFP := loongClassify(v.Type()); useFP {
+		for _, l := range leaves {
+			src := unsafe.Add(ptr, l.offset)
+			switch {
+			case l.isFloat && l.kind == reflect.Float32:
+				// NaN-box the single-precision value in the 64-bit FP register.
+				addFloat(uintptr(*(*uint32)(src)) | 0xFFFFFFFF_00000000)
+			case l.isFloat:
+				addFloat(uintptr(*(*uint64)(src)))
+			default:
+				addInt(loongLoadInt(src, l))
+			}
+		}
 		return keepAlive
 	}
 
-	if size := v.Type().Size(); size <= 16 {
-		placeRegisters(v, addFloat, addInt)
-	} else {
-		keepAlive = placeStack(v, keepAlive, addInt)
+	// Integer calling convention: pass the raw aggregate in one or two GARs.
+	var words [16]byte
+	copy(words[:], unsafe.Slice((*byte)(ptr), size))
+	addInt(*(*uintptr)(unsafe.Pointer(&words[0])))
+	if size > 8 {
+		addInt(*(*uintptr)(unsafe.Pointer(&words[8])))
 	}
-	return keepAlive // the struct was allocated so don't panic
+	return keepAlive
 }
 
-func placeRegisters(v reflect.Value, addFloat func(uintptr), addInt func(uintptr)) {
-	var val uint64
-	var shift byte
-	var flushed bool
-	class := _NO_CLASS
-	var place func(v reflect.Value)
-	place = func(v reflect.Value) {
-		var numFields int
-		if v.Kind() == reflect.Struct {
-			numFields = v.Type().NumField()
-		} else {
-			numFields = v.Type().Len()
-		}
-		for k := 0; k < numFields; k++ {
-			flushed = false
-			var f reflect.Value
-			if v.Kind() == reflect.Struct {
-				f = v.Field(k)
-			} else {
-				f = v.Index(k)
-			}
-			align := byte(f.Type().Align()*8 - 1)
-			shift = (shift + align) &^ align
-			if shift >= 64 {
-				shift = 0
-				flushed = true
-				if class == _FLOAT {
-					addFloat(uintptr(val))
-				} else {
-					addInt(uintptr(val))
-				}
-			}
-			switch f.Type().Kind() {
-			case reflect.Struct:
-				place(f)
-			case reflect.Bool:
-				if f.Bool() {
-					val |= 1 << shift
-				}
-				shift += 8
-				class |= _INT
-			case reflect.Uint8:
-				val |= f.Uint() << shift
-				shift += 8
-				class |= _INT
-			case reflect.Uint16:
-				val |= f.Uint() << shift
-				shift += 16
-				class |= _INT
-			case reflect.Uint32:
-				val |= f.Uint() << shift
-				shift += 32
-				class |= _INT
-			case reflect.Uint64, reflect.Uint, reflect.Uintptr:
-				addInt(uintptr(f.Uint()))
-				shift = 0
-				flushed = true
-				class = _NO_CLASS
-			case reflect.Int8:
-				val |= uint64(f.Int()&0xFF) << shift
-				shift += 8
-				class |= _INT
-			case reflect.Int16:
-				val |= uint64(f.Int()&0xFFFF) << shift
-				shift += 16
-				class |= _INT
-			case reflect.Int32:
-				val |= uint64(f.Int()&0xFFFF_FFFF) << shift
-				shift += 32
-				class |= _INT
-			case reflect.Int64, reflect.Int:
-				addInt(uintptr(f.Int()))
-				shift = 0
-				flushed = true
-				class = _NO_CLASS
-			case reflect.Float32:
-				if class == _FLOAT {
-					addFloat(uintptr(val))
-					val = 0
-					shift = 0
-				}
-				val |= uint64(math.Float32bits(float32(f.Float()))) << shift
-				shift += 32
-				class |= _FLOAT
-			case reflect.Float64:
-				addFloat(uintptr(math.Float64bits(float64(f.Float()))))
-				shift = 0
-				flushed = true
-				class = _NO_CLASS
-			case reflect.Ptr, reflect.UnsafePointer:
-				addInt(f.Pointer())
-				shift = 0
-				flushed = true
-				class = _NO_CLASS
-			case reflect.Array:
-				place(f)
-			default:
-				panic("purego: unsupported kind " + f.Kind().String())
-			}
-		}
-	}
-	place(v)
-	if !flushed {
-		if class == _FLOAT {
-			addFloat(uintptr(val))
-		} else {
-			addInt(uintptr(val))
-		}
+// loongLoadInt reads an integer leaf into a register value, sign-extending
+// signed members and zero-extending the rest.
+func loongLoadInt(src unsafe.Pointer, l loongLeaf) uintptr {
+	switch l.kind {
+	case reflect.Int8:
+		return uintptr(int64(*(*int8)(src)))
+	case reflect.Int16:
+		return uintptr(int64(*(*int16)(src)))
+	case reflect.Int32:
+		return uintptr(int64(*(*int32)(src)))
+	case reflect.Int, reflect.Int64:
+		return uintptr(*(*int64)(src))
+	case reflect.Bool, reflect.Uint8:
+		return uintptr(*(*uint8)(src))
+	case reflect.Uint16:
+		return uintptr(*(*uint16)(src))
+	case reflect.Uint32:
+		return uintptr(*(*uint32)(src))
+	default:
+		return uintptr(*(*uint64)(src))
 	}
 }
 

--- a/struct_test.go
+++ b/struct_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024 The Ebitengine Authors
 
-//go:build (darwin || linux || windows) && (amd64 || arm64 || loong64 || ppc64le || riscv64 || s390x)
+//go:build (darwin || linux || windows) && (amd64 || arm64 || loong64)
 
 package purego_test
 

--- a/struct_test.go
+++ b/struct_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024 The Ebitengine Authors
 
-//go:build (darwin || linux || windows) && (amd64 || arm64)
+//go:build (darwin || linux || windows) && (amd64 || arm64 || loong64 || ppc64le || riscv64 || s390x)
 
 package purego_test
 
@@ -81,6 +81,11 @@ func TestRegisterFunc_structArgs(t *testing.T) {
 		if imp.usesCallbacks && runtime.GOOS == "windows" {
 			// Callbacks on Windows use the stdlib syscall.NewCallback, which does
 			// not support struct arguments or returns.
+			continue
+		}
+		if imp.usesCallbacks && runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+			// Struct arguments and returns in callbacks are only supported on
+			// amd64 and arm64.
 			continue
 		}
 		t.Run(imp.name, func(t *testing.T) {
@@ -906,6 +911,11 @@ func TestRegisterFunc_structReturns(t *testing.T) {
 		if imp.usesCallbacks && runtime.GOOS == "windows" {
 			// Callbacks on Windows use the stdlib syscall.NewCallback, which does
 			// not support struct arguments or returns.
+			continue
+		}
+		if imp.usesCallbacks && runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+			// Struct arguments and returns in callbacks are only supported on
+			// amd64 and arm64.
 			continue
 		}
 		t.Run(imp.name, func(t *testing.T) {

--- a/struct_test.go
+++ b/struct_test.go
@@ -84,8 +84,6 @@ func TestRegisterFunc_structArgs(t *testing.T) {
 			continue
 		}
 		if imp.usesCallbacks && runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
-			// Struct arguments and returns in callbacks are only supported on
-			// amd64 and arm64.
 			continue
 		}
 		t.Run(imp.name, func(t *testing.T) {
@@ -914,8 +912,6 @@ func TestRegisterFunc_structReturns(t *testing.T) {
 			continue
 		}
 		if imp.usesCallbacks && runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
-			// Struct arguments and returns in callbacks are only supported on
-			// amd64 and arm64.
 			continue
 		}
 		t.Run(imp.name, func(t *testing.T) {

--- a/syscall_unix.go
+++ b/syscall_unix.go
@@ -64,7 +64,7 @@ func compileCallback(fn any) uintptr {
 			if i == 0 && in.AssignableTo(reflect.TypeFor[CDecl]()) {
 				continue
 			}
-			ensureStructSupported()
+			ensureCallbackStructSupported()
 			checkStructFieldsSupported(in)
 			continue
 		case reflect.Interface, reflect.Func, reflect.Slice,

--- a/syscall_unix.go
+++ b/syscall_unix.go
@@ -77,9 +77,13 @@ output:
 	switch {
 	case ty.NumOut() == 1:
 		switch ty.Out(0).Kind() {
+		case reflect.Struct:
+			ensureCallbackStructSupported()
+			checkStructFieldsSupported(ty.Out(0))
+			break output
 		case reflect.Pointer, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
-			reflect.Bool, reflect.UnsafePointer, reflect.Struct:
+			reflect.Bool, reflect.UnsafePointer:
 			break output
 		}
 		panic("purego: unsupported return type: " + ty.String())


### PR DESCRIPTION
# What issue is this addressing?

Updates #474

## What _type_ of issue is this addressing?

feature

## What this PR does | solves

Enables passing and returning C structs by value through `RegisterFunc` /
`RegisterLibFunc` on **linux/loong64**.

The per-architecture code added in #431 was unreachable behind a guard that
only permitted amd64 and arm64. This PR makes that guard **direction-aware** and
adds loong64:

- `ensureStructSupported` gates the forward call path (`RegisterFunc`) and now
  allows loong64 in addition to amd64/arm64.
- A new `ensureCallbackStructSupported` keeps the callback path (`NewCallback`)
  restricted to amd64/arm64, where `getCallbackStruct` / `setStruct` are
  implemented. Struct callbacks remain unsupported on loong64.
- Struct return types are now validated when creating a callback, so an
  unsupported signature fails at `NewCallback` time instead of panicking later.

The loong64 `struct_loong64.go` implementation was rewritten to follow the
LoongArch hard-float calling convention: an aggregate uses FP registers only
when, after flattening nested structs/arrays and ignoring blank padding fields,
it has one or two floating-point members and nothing else, or exactly one
floating-point member with one integer member; everything else uses the integer
convention. `float32` values are NaN-boxed in FP registers. This was validated
against the real compiler with `zig cc -target loongarch64-linux-gnu -S` and by
the QEMU test job.

**Scope:** only loong64 is enabled here. ppc64le, riscv64, and s390x still use
the old `isAllSameFloat` heuristic, which mishandles floating-point aggregates
(ppc64le currently crashes under test). Each will be enabled in its own PR once
its calling convention is implemented correctly. `README.md` reflects this:
loong64 moves to "structs when calling C functions, but not in callbacks", while
the other three stay unsupported.

---

Authored by Claude (Claude Code) on behalf of @hajimehoshi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
