### PR TITLE
.github/workflows: use macos-15 instead of macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,10 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        # macos-15 is used instead of macos-latest. On macOS 26, dyld refuses to
+        # run a binary without an LC_UUID load command, which the Go linker emits
+        # only since Go 1.24. See #482.
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15, windows-latest]
         go: ['1.18.x', '1.19.x', '1.20.x', '1.21.x', '1.22.x', '1.23.x', '1.24.x', '1.25.x', '1.26.x']
     name: Test with Go ${{ matrix.go }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# What issue is this addressing?

Updates #482

## What _type_ of issue is this addressing?

bug

## What this PR does | solves

CI on this branch is red because GitHub's `macos-latest` label has migrated to macOS 26. On macOS 26, dyld refuses to exec a Mach-O binary that has no `LC_UUID` load command, so the test binaries abort before `main` runs:

```
dyld[9810]: missing LC_UUID load command in .../b001/purego.test
signal: abort trap
FAIL	github.com/ebitengine/purego	0.003s
```

The Go linker emits `LC_UUID` only when `-B` is passed, and `-B gobuildid` became the default in Go 1.24 (`cmd/link/internal/ld/main.go`). Go 1.20 through 1.23 therefore produce binaries that macOS 26 will not start. CoreFoundation, pulled in by the cgo-enabled `net` package, is what triggers dyld's check, which is why `CGO_ENABLED=0` passes and `CGO_ENABLED=1` fails within the same step.

Measured on macOS 26.5 with this branch's tree:

| Go | `LC_UUID` | `LC_BUILD_VERSION` | `CGO_ENABLED=1` test binary |
|---|---|---|---|
| 1.18.10 | absent | minos 12.0 | runs |
| 1.19.13 | absent | minos 12.x | runs |
| 1.20.14 | absent | minos 26.0 | dyld: missing LC_UUID |
| 1.21.x | absent | — | expected to fail |
| 1.22.12 | absent | minos 26.x | dyld: missing LC_UUID |
| 1.23.11 | absent | minos 26.x | dyld: missing LC_UUID |
| 1.25.7 / 1.26.5 | present | minos 26.x | runs |

Go 1.18/1.19 survive only because their linker stamps an old SDK version in `LC_BUILD_VERSION`, so dyld applies the pre-26 rules. That is incidental, not something to rely on.

This branch supports Go 1.18 and later, so the affected Go versions cannot simply be dropped from the matrix. Pinning the runner to `macos-15` keeps the full matrix working. `macos-15` is the arm64 image, the same architecture `macos-latest` resolved to before and after the macOS 26 migration, so test coverage is unchanged.

### Notes for reviewers

- `main` needs no equivalent change: #469 reduced its matrix to Go 1.25+, all of which emit `LC_UUID` by default. The same commit passed on `main` and failed on this branch on the same day.
- Alternatives considered and rejected:
  - `-ldflags=-B=gobuildid` on the macOS test commands works for Go 1.22/1.23, but Go 1.20/1.21 reject the flag (`-B argument must start with 0x: gobuildid`) and cannot emit `LC_UUID` at all.
  - Dropping Go 1.20-1.23 from the macOS matrix loses coverage that `macos-15` can still provide.
- This fix lasts only as long as GitHub offers `macos-15`. Once that label is retired, the Go 1.20-1.23 macOS cells will have to be dropped rather than fixed.
- Job names change from `... on macos-latest` to `... on macos-15`. This branch has no branch protection, so no required status check is pinned to the old names.

---

Authored by Claude (Claude Code), on behalf of @hajimehoshi.
