### PR TITLE
internal/fakecgo: compilation error for old Go

### DIFF
--- a/internal/fakecgo/threadentry_test.go
+++ b/internal/fakecgo/threadentry_test.go
@@ -33,10 +33,10 @@ func TestThreadEntryReturn(t *testing.T) {
 	// enough to catch a broken teardown while staying quick under emulation.
 	const rounds = 10
 	const workers = 16
-	for range rounds {
+	for i := 0; i < rounds; i++ {
 		var wg sync.WaitGroup
 		wg.Add(workers)
-		for range workers {
+		for j := 0; j < workers; j++ {
 			go func() {
 				defer wg.Done()
 				runtime.LockOSThread()


### PR DESCRIPTION

<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
Updates #485

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Fixes a compilation error for old Go where range over integers is not available.
