### PR TITLE
Fix typo in doc comment

### DIFF
--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -21,7 +21,7 @@ func syscall_syscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 // function with one uintptr-sized result. The function must not have arguments with size larger than the
 // size of uintptr. Only a limited number of callbacks may be created in a single Go process, and any memory
 // allocated for these callbacks is never released. Between NewCallback and NewCallbackCDecl, at least 1024
-// callbacks can always be created. Although this function is similiar to the darwin version it may act
+// callbacks can always be created. Although this function is similar to the darwin version it may act
 // differently.
 func NewCallback(fn any) uintptr {
 	isCDecl := false


### PR DESCRIPTION
Small typo fix in the `NewCallback` doc comment: "similiar" -> "similar".
