### PR TITLE
all: remove zcallback_*.s from the external code list

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ This is a list of the copied files:
 
 * `abi_*.h` from package `runtime/cgo`
 * `wincallback.go` from package `runtime`
-* `zcallback_*.s` from package `runtime`
 * `internal/fakecgo/abi_*.h` from package `runtime/cgo`
 * `internal/fakecgo/asm_GOARCH.s` from package `runtime/cgo`
 * `internal/fakecgo/callbacks.go` from package `runtime/cgo`

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This is a list of the copied files:
 
 * `abi_*.h` from package `runtime/cgo`
 * `wincallback.go` from package `runtime`
-* `zcallback_darwin_*.s` from package `runtime`
+* `zcallback_*.s` from package `runtime`
 * `internal/fakecgo/abi_*.h` from package `runtime/cgo`
 * `internal/fakecgo/asm_GOARCH.s` from package `runtime/cgo`
 * `internal/fakecgo/callbacks.go` from package `runtime/cgo`


### PR DESCRIPTION
# What issue is this addressing?

None, spotted it while working out which bits came from the Go runtime.

## What _type_ of issue is this addressing?

bug (well, not really - just a small docs issue)

## What this PR does | solves

~~The external code list points at `zcallback_darwin_*.s`, but those got renamed to `zcallback_<GOARCH>.s` in #98 when darwin and linux were merged, so the entry doesn't name a file that exists any more. Every other entry in the list still resolves, so this is the only one.~~

Turns out the line never attributed anything, the files are generated locally by `wincallback.go` which is already listed. Dropping it instead, thanks @hajimehoshi.
