### PR TITLE
.github/workflows: test against Go 1.27

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest, windows-11-arm]
-        go: ['1.25.x', '1.26.x', '1.27.0-rc.2']
+        go: ['1.25.x', '1.26.x', '1.27.x']
     name: Test with Go ${{ matrix.go }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
@@ -204,7 +204,7 @@ jobs:
   minor-arches:
     strategy:
       matrix:
-        go: ['1.25.x', '1.26.x', '1.27.0-rc.2']
+        go: ['1.25.x', '1.26.x', '1.27.x']
     name: Test with Go ${{ matrix.go }} on Linux minor architectures
     runs-on: ubuntu-latest
     defaults:
@@ -344,7 +344,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.25.x', '1.26.x', '1.27.0-rc.2']
+        go: ['1.25.x', '1.26.x', '1.27.x']
     name: Test with Go ${{ matrix.go }} on Android amd64
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
Go 1.27 has been released, so the CI matrix no longer needs to pin the release candidate. This replaces `1.27.0-rc.2` with `1.27.x` in the three job matrices in `.github/workflows/test.yml`, matching the style of the existing `1.25.x` / `1.26.x` entries.

The `if: startsWith(matrix.go, '1.27.')` guard for the Linux minor-architecture build still matches `1.27.x`, so it is unchanged.

Authored by Claude (Claude Code), on behalf of @hajimehoshi.