### PR TITLE
purego: fix returning a C function pointer as a Go func

### DIFF
--- a/func.go
+++ b/func.go
@@ -409,7 +409,9 @@ func RegisterFunc(fptr any, cfn uintptr) {
 			v = reflect.NewAt(outType, unsafe.Pointer(&a1)).Elem()
 		case reflect.Func:
 			// wrap this C function in a nicely typed Go function
-			RegisterFunc(v.Addr().Interface(), syscall.a1)
+			if syscall.a1 != 0 {
+				RegisterFunc(v.Addr().Interface(), syscall.a1)
+			}
 		case reflect.String:
 			v.SetString(strings.GoString(syscall.a1))
 		case reflect.Float32:

--- a/func.go
+++ b/func.go
@@ -409,8 +409,7 @@ func RegisterFunc(fptr any, cfn uintptr) {
 			v = reflect.NewAt(outType, unsafe.Pointer(&a1)).Elem()
 		case reflect.Func:
 			// wrap this C function in a nicely typed Go function
-			v = reflect.New(outType)
-			RegisterFunc(v.Interface(), syscall.a1)
+			RegisterFunc(v.Addr().Interface(), syscall.a1)
 		case reflect.String:
 			v.SetString(strings.GoString(syscall.a1))
 		case reflect.Float32:

--- a/func_test.go
+++ b/func_test.go
@@ -239,6 +239,16 @@ func TestABI(t *testing.T) {
 			t.Fatalf("%s: got %q, want %q", cName, res, want)
 		}
 	}
+	{
+		const cName = "return_func_ptr"
+		var fn func() func(a, b int32) int32
+		purego.RegisterLibFunc(&fn, lib, cName)
+		add := fn()
+		const expect = 5
+		if res := add(2, 3); res != expect {
+			t.Fatalf("%s: got %d, want %d", cName, res, expect)
+		}
+	}
 }
 
 func TestABI_ArgumentPassing(t *testing.T) {

--- a/func_test.go
+++ b/func_test.go
@@ -249,6 +249,14 @@ func TestABI(t *testing.T) {
 			t.Fatalf("%s: got %d, want %d", cName, res, expect)
 		}
 	}
+	{
+		const cName = "return_null_func_ptr"
+		var fn func() func(a, b int32) int32
+		purego.RegisterLibFunc(&fn, lib, cName)
+		if fn() != nil {
+			t.Fatalf("%s: got a non-nil func, want nil", cName)
+		}
+	}
 }
 
 func TestABI_ArgumentPassing(t *testing.T) {

--- a/testdata/abitest/abi_test.c
+++ b/testdata/abitest/abi_test.c
@@ -197,3 +197,13 @@ double arm_float64_unaligned_on_stack(uintptr_t a1, uintptr_t a2, uintptr_t a3, 
     return (double)a1 * 1 + (double)a2 * 2 + (double)a3 * 3 + (double)a4 * 4 +
            (double)a5 * 5 + a6;
 }
+
+typedef int32_t (*AddFunc)(int32_t, int32_t);
+
+int32_t returned_add(int32_t a, int32_t b) {
+    return a + b;
+}
+
+AddFunc return_func_ptr(void) {
+    return returned_add;
+}

--- a/testdata/abitest/abi_test.c
+++ b/testdata/abitest/abi_test.c
@@ -207,3 +207,7 @@ int32_t returned_add(int32_t a, int32_t b) {
 AddFunc return_func_ptr(void) {
     return returned_add;
 }
+
+AddFunc return_null_func_ptr(void) {
+    return NULL;
+}


### PR DESCRIPTION
# What issue is this addressing?

#501

## What _type_ of issue is this addressing?

bug

## What this PR does | solves

The `RegisterFunc` type table has `func <=> C function` in it, but that only holds in the argument direction. Declare a C function as returning a func, and calling it panics:

```
panic: reflect.MakeFunc: value of type *func(int32, int32) int32 is not assignable to type func(int32, int32) int32
```

Registering is fine, it's the call that goes, and it goes for every signature. Every other case in that return switch leaves the result as the declared type. The `reflect.Func` case swapped in a `*func`, registered into that, and handed the pointer back to `MakeFunc`, which wont take it.

If the C function returns NULL the inner `RegisterFunc` still panics `purego: cfn is nil`. Left that alone, since whether it should hand you a nil Go func instead looked like your call rather than a bug.

Test is a block in `TestABI` plus a `return_func_ptr` helper in `abi_test.c`, and it fails on main with teh panic above. Been broken since #49 back in 2022, which is probably why nobody's hit it: you'd normally take the pointer back as a `uintptr` and register it youself, and nothing in the repo declares a func return.

