### PR TITLE
all: use range-over-int in counting loops

### DIFF
--- a/func.go
+++ b/func.go
@@ -151,14 +151,14 @@ func RegisterFunc(fptr any, cfn uintptr) {
 		floatArgRegs := numOfFloatRegisters()
 		ptrSize := unsafe.Sizeof(uintptr(0))
 		var stack int
-		for i := 0; i < ty.NumIn(); i++ {
+		for i := range ty.NumIn() {
 			arg := ty.In(i)
 			switch arg.Kind() {
 			case reflect.Func:
 				// This only does preliminary testing to ensure the CDecl argument
 				// is the first argument. Full testing is done when the callback is actually
 				// created in NewCallback.
-				for j := 0; j < arg.NumIn(); j++ {
+				for j := range arg.NumIn() {
 					in := arg.In(j)
 					if !in.AssignableTo(reflect.TypeFor[CDecl]()) {
 						continue
@@ -607,7 +607,7 @@ func isAllSameFloat(ty reflect.Type) (allFloats bool, numFields int) {
 	if first != reflect.Float32 && first != reflect.Float64 {
 		allFloats = false
 	}
-	for i := 0; i < ty.NumField(); i++ {
+	for i := range ty.NumField() {
 		if !isABIField(ty.Field(i)) {
 			continue
 		}
@@ -627,7 +627,7 @@ func isAllSameFloat(ty reflect.Type) (allFloats bool, numFields int) {
 }
 
 func checkStructFieldsSupported(ty reflect.Type) {
-	for i := 0; i < ty.NumField(); i++ {
+	for i := range ty.NumField() {
 		if !isABIField(ty.Field(i)) {
 			continue
 		}
@@ -732,7 +732,7 @@ func estimateStackBytes(ty reflect.Type) int {
 	var numInts, numFloats int
 	var stackBytes int
 
-	for i := 0; i < ty.NumIn(); i++ {
+	for i := range ty.NumIn() {
 		arg := ty.In(i)
 		size := int(arg.Size())
 

--- a/func_test.go
+++ b/func_test.go
@@ -60,7 +60,7 @@ func TestRegisterFunc_ConcurrentPointerReturn(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for i := range runtime.NumCPU() {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()

--- a/internal/fakecgo/go_libinit.go
+++ b/internal/fakecgo/go_libinit.go
@@ -52,7 +52,7 @@ func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe
 	tries := ts.Nsec
 	var err int
 
-	for tries = 0; tries < 20; tries++ {
+	for tries = range 20 {
 		// inlined this call because it ran out of stack when inlining was disabled
 		err = int(call5(pthread_createABI0, uintptr(unsafe.Pointer(thread)), uintptr(unsafe.Pointer(attr)), uintptr(pfn), uintptr(unsafe.Pointer(arg)), 0))
 		if err == 0 {

--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -472,7 +472,7 @@ func encodeType(typ reflect.Type, insidePtr bool) (string, error) {
 		encoding.WriteString(encStructBegin)
 		encoding.WriteString(typ.Name())
 		encoding.WriteString("=")
-		for i := 0; i < typ.NumField(); i++ {
+		for i := range typ.NumField() {
 			f := typ.Field(i)
 			if f.Type.ConvertibleTo(hostLayoutType) {
 				// The structs.HostLayout marker is a signal to the Go compiler

--- a/struct_amd64.go
+++ b/struct_amd64.go
@@ -100,7 +100,7 @@ func getStruct(outType reflect.Type, syscall syscallArgs) (v reflect.Value) {
 }
 
 func isAllFloats(ty reflect.Type) bool {
-	for i := 0; i < ty.NumField(); i++ {
+	for i := range ty.NumField() {
 		f := ty.Field(i)
 		if !isABIField(f) {
 			continue
@@ -220,7 +220,7 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 			numFields = v.Type().Len()
 		}
 
-		for i := 0; i < numFields; i++ {
+		for i := range numFields {
 			if v.Kind() == reflect.Struct && !isABIField(v.Type().Field(i)) {
 				continue
 			}
@@ -390,7 +390,7 @@ func getCallbackStruct(inType reflect.Type, frame unsafe.Pointer, floatsN *int, 
 
 	// Count how many integer and SSE registers this struct needs.
 	var needInts, needFloats int
-	for i := 0; i < numEightbytes; i++ {
+	for i := range numEightbytes {
 		class := classifyEightbyte(inType, uintptr(i)*8, uintptr(i)*8+8)
 		if class == _SSE {
 			needFloats++
@@ -408,7 +408,7 @@ func getCallbackStruct(inType reflect.Type, frame unsafe.Pointer, floatsN *int, 
 
 	// Read each eightbyte from its appropriate register class.
 	var r1, r2 uintptr
-	for i := 0; i < numEightbytes; i++ {
+	for i := range numEightbytes {
 		class := classifyEightbyte(inType, uintptr(i)*8, uintptr(i)*8+8)
 		if class == _SSE {
 			if i == 0 {
@@ -490,7 +490,7 @@ func doClassifyEightbyte(t reflect.Type, base, start, end uintptr) int {
 	switch t.Kind() {
 	case reflect.Struct:
 		class := _NO_CLASS
-		for i := 0; i < t.NumField(); i++ {
+		for i := range t.NumField() {
 			f := t.Field(i)
 			class |= doClassifyEightbyte(f.Type, base+f.Offset, start, end)
 		}
@@ -498,7 +498,7 @@ func doClassifyEightbyte(t reflect.Type, base, start, end uintptr) int {
 	case reflect.Array:
 		class := _NO_CLASS
 		elemSize := t.Elem().Size()
-		for i := 0; i < t.Len(); i++ {
+		for i := range t.Len() {
 			class |= doClassifyEightbyte(t.Elem(), base+uintptr(i)*elemSize, start, end)
 		}
 		return class

--- a/struct_arm64.go
+++ b/struct_arm64.go
@@ -119,7 +119,7 @@ func placeRegistersArm64(v reflect.Value, addFloat func(uintptr), addInt func(ui
 		} else {
 			numFields = v.Type().Len()
 		}
-		for k := 0; k < numFields; k++ {
+		for k := range numFields {
 			if v.Kind() == reflect.Struct && !isABIField(v.Type().Field(k)) {
 				continue
 			}
@@ -249,7 +249,7 @@ func isHFA(t reflect.Type) bool {
 	switch first.Type.Kind() {
 	case reflect.Float32, reflect.Float64:
 		firstKind := first.Type.Kind()
-		for i := 0; i < numFields; i++ {
+		for i := range numFields {
 			if abiField(t, i).Type.Kind() != firstKind {
 				return false
 			}
@@ -263,7 +263,7 @@ func isHFA(t reflect.Type) bool {
 			return false
 		}
 	case reflect.Struct:
-		for i := 0; i < numABIFields(first.Type); i++ {
+		for range numABIFields(first.Type) {
 			if !isHFA(first.Type) {
 				return false
 			}
@@ -292,7 +292,7 @@ func isHVA(t reflect.Type) bool {
 	switch first.Type.Kind() {
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Int8, reflect.Int16, reflect.Int32:
 		firstKind := first.Type.Kind()
-		for i := 0; i < numFields; i++ {
+		for i := range numFields {
 			if abiField(t, i).Type.Kind() != firstKind {
 				return false
 			}
@@ -546,7 +546,7 @@ func bundleStackArgs(stackArgs []reflect.Value, addStack func(uintptr)) {
 
 	// Set values (skip padding fields)
 	argIndex := 0
-	for j := 0; j < structInstance.NumField(); j++ {
+	for j := range structInstance.NumField() {
 		fieldName := structType.Field(j).Name
 		if stdstrings.HasPrefix(fieldName, paddingFieldPrefix) {
 			continue

--- a/struct_riscv64.go
+++ b/struct_riscv64.go
@@ -37,7 +37,7 @@ func getStruct(outType reflect.Type, syscall syscallArgs) reflect.Value {
 			if abiField(outType, 0).Type.Kind() == reflect.Float32 {
 				// float32 values are NaN-boxed in FP regs; use low 32 bits only
 				f := []uintptr{syscall.f1, syscall.f2, syscall.f3, syscall.f4}
-				for i := 0; i < numFields; i++ {
+				for i := range numFields {
 					*(*uint32)(unsafe.Pointer(&buf[i*4])) = uint32(f[i])
 				}
 			} else {

--- a/struct_s390x.go
+++ b/struct_s390x.go
@@ -37,7 +37,7 @@ func getStruct(outType reflect.Type, syscall syscallArgs) reflect.Value {
 			if abiField(outType, 0).Type.Kind() == reflect.Float32 {
 				// float32 values in FP regs
 				f := []uintptr{syscall.f1, syscall.f2, syscall.f3, syscall.f4}
-				for i := 0; i < numFields; i++ {
+				for i := range numFields {
 					*(*uint32)(unsafe.Pointer(&buf[i*4])) = uint32(f[i])
 				}
 			} else {

--- a/syscall_bench_test.go
+++ b/syscall_bench_test.go
@@ -116,7 +116,7 @@ func BenchmarkCallingMethods(b *testing.B) {
 				args := int64sToUintptrs(tc.args)
 				var result uintptr
 				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					result, _, _ = purego.SyscallN(tc.goFnPtr, args...)
 				}
 				b.StopTimer()
@@ -135,7 +135,7 @@ func BenchmarkCallingMethods(b *testing.B) {
 				args := int64sToUintptrs(tc.args)
 				var result uintptr
 				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					result, _, _ = purego.SyscallN(tc.cFnPtr, args...)
 				}
 				b.StopTimer()
@@ -165,7 +165,7 @@ func BenchmarkCallingMethods(b *testing.B) {
 
 				var result uintptr
 				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					result, _, _ = purego.SyscallN(tc.cCallbackPtr, callbackArgs...)
 				}
 				b.StopTimer()

--- a/syscall_linux_test.go
+++ b/syscall_linux_test.go
@@ -192,12 +192,12 @@ func TestDlopenThenAllThreadsSyscall(t *testing.T) {
 	}
 
 	cb := purego.NewCallback(goFunc)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		callCallback(cb, "hello")
 	}
 
 	// Step 2: Generate thread churn + AllThreadsSyscall (via Setuid).
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		c := make(chan struct{})
 		go func() {
 			runtime.LockOSThread()

--- a/syscall_unix.go
+++ b/syscall_unix.go
@@ -27,7 +27,7 @@ func syscall_syscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 // provides similar functionality to windows.NewCallback it is distinct.
 func NewCallback(fn any) uintptr {
 	ty := reflect.TypeOf(fn)
-	for i := 0; i < ty.NumIn(); i++ {
+	for i := range ty.NumIn() {
 		in := ty.In(i)
 		if !in.AssignableTo(reflect.TypeFor[CDecl]()) {
 			continue
@@ -58,7 +58,7 @@ func compileCallback(fn any) uintptr {
 		panic("purego: function must not be nil")
 	}
 	ty := val.Type()
-	for i := 0; i < ty.NumIn(); i++ {
+	for i := range ty.NumIn() {
 		in := ty.In(i)
 		switch in.Kind() {
 		case reflect.Struct:

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -26,7 +26,7 @@ func syscall_syscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 func NewCallback(fn any) uintptr {
 	isCDecl := false
 	ty := reflect.TypeOf(fn)
-	for i := 0; i < ty.NumIn(); i++ {
+	for i := range ty.NumIn() {
 		in := ty.In(i)
 		if !in.AssignableTo(reflect.TypeOf(CDecl{})) {
 			continue

--- a/wincallback.go
+++ b/wincallback.go
@@ -35,7 +35,7 @@ func genasm386() {
 
 TEXT callbackasm(SB), NOSPLIT|NOFRAME, $0
 `)
-	for i := 0; i < maxCallback; i++ {
+	for i := range maxCallback {
 		fmt.Fprintf(&buf, "\tMOVL $%d, CX\n", i)
 		buf.WriteString("\tJMP  callbackasm1(SB)\n")
 	}
@@ -63,7 +63,7 @@ func genasmAmd64() {
 
 TEXT callbackasm(SB), NOSPLIT|NOFRAME, $0
 `)
-	for i := 0; i < maxCallback; i++ {
+	for range maxCallback {
 		buf.WriteString("\tCALL callbackasm1(SB)\n")
 	}
 	if err := os.WriteFile("zcallback_amd64.s", buf.Bytes(), 0644); err != nil {
@@ -90,7 +90,7 @@ func genasmArm() {
 
 TEXT callbackasm(SB), NOSPLIT|NOFRAME, $0
 `)
-	for i := 0; i < maxCallback; i++ {
+	for i := range maxCallback {
 		fmt.Fprintf(&buf, "\tMOVW $%d, R12\n", i)
 		buf.WriteString("\tB    callbackasm1(SB)\n")
 	}
@@ -118,7 +118,7 @@ func genasmArm64() {
 
 TEXT callbackasm(SB), NOSPLIT|NOFRAME, $0
 `)
-	for i := 0; i < maxCallback; i++ {
+	for i := range maxCallback {
 		fmt.Fprintf(&buf, "\tMOVD $%d, R12\n", i)
 		buf.WriteString("\tB    callbackasm1(SB)\n")
 	}
@@ -146,7 +146,7 @@ func genasmLoong64() {
 
 TEXT callbackasm(SB), NOSPLIT|NOFRAME, $0
 `)
-	for i := 0; i < maxCallback; i++ {
+	for i := range maxCallback {
 		fmt.Fprintf(&buf, "\tMOVV $%d, R12\n", i)
 		buf.WriteString("\tJMP  callbackasm1(SB)\n")
 	}
@@ -174,7 +174,7 @@ func genasmPpc64le() {
 
 TEXT callbackasm(SB), NOSPLIT|NOFRAME, $0
 `)
-	for i := 0; i < maxCallback; i++ {
+	for i := range maxCallback {
 		fmt.Fprintf(&buf, "\tMOVD $%d, R11\n", i)
 		buf.WriteString("\tBR   callbackasm1(SB)\n")
 	}
@@ -206,7 +206,7 @@ func genasmRiscv64() {
 
 TEXT callbackasm(SB), NOSPLIT|NOFRAME, $0
 `)
-	for i := 0; i < maxCallback; i++ {
+	for i := range maxCallback {
 		space := " "
 		if i <= 32 {
 			fmt.Fprintf(&buf, "\tPCALIGN $8\n")
@@ -240,7 +240,7 @@ func genasmS390x() {
 
 TEXT callbackasm(SB), NOSPLIT|NOFRAME, $0
 `)
-	for i := 0; i < maxCallback; i++ {
+	for i := range maxCallback {
 		fmt.Fprintf(&buf, "\tMOVD $%d, R0\n", i)
 		buf.WriteString("\tBR   callbackasm1(SB)\n")
 	}


### PR DESCRIPTION
# What issue is this addressing?
None; this is a standalone cleanup.

## What _type_ of issue is this addressing?
refactor (no behavior change)

## What this PR does | solves
Go 1.22 added range over an integer. This converts the 37 three-clause
counting loops that translate directly, most of them walking reflect fields
or function arguments, and drops the index where the body never used it.

Found with `go fix -rangeint ./...` run across the GOOS/GOARCH matrix so the
per-architecture files were covered, then extended by hand to the cases that
analyzer skips conservatively:

- Call limits it cannot prove invariant: `NumIn`, `NumField`, `Len`, `NumCPU`
  and `numABIFields`. All are pure, so evaluating them once instead of on
  every iteration does not change behavior. `func.go` already used this form.
- `numFields` in the `place` closures of `struct_amd64.go` and
  `struct_arm64.go`, assigned in two branches before the loop and never
  inside it.
- `wincallback.go`, which carries `//go:build ignore` and so is never
  analyzed. It generates the `zcallback_*.s` files; regenerating with the
  converted loops reproduces all eight byte for byte.

Loops a range cannot express are left as they are: the 8-byte strides in
`copyStruct8ByteChunks`, `placeStack` and `addStruct`; the field scan in
amd64 `getStruct`, whose index is read after the loop; the compound
condition in `setStruct`; and the one-based loops in `objc` that skip the
first argument, emitted separately as `encId`.

`gofmt -s -l` is clean, `go vet` is clean on 10 platforms and `go build` on
all 15 that build today, and `go test ./...` passes on darwin/arm64.

---
Authored by Claude (Claude Code), on behalf of @hajimehoshi.
