### PR TITLE
purego: apply go fix modernizations

### DIFF
--- a/syscall_linux_test.go
+++ b/syscall_linux_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"syscall"
 	"testing"
@@ -119,8 +119,8 @@ func compareStatus(filter, expect string) error {
 			//    "... : bad file descriptor.
 			continue
 		}
-		lines := strings.Split(string(d), "\n")
-		for _, line := range lines {
+		lines := strings.SplitSeq(string(d), "\n")
+		for line := range lines {
 			// Different kernel vintages pad differently.
 			line = strings.TrimSpace(line)
 			if strings.HasPrefix(line, "Pid:\t") {
@@ -149,7 +149,7 @@ func compareStatus(filter, expect string) error {
 					// https://github.com/golang/go/issues/46145
 					// Containers don't reliably output this line in sorted order so manually sort and compare that.
 					a := strings.Split(line[8:], " ")
-					sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+					slices.Sort(a)
 					got := strings.Join(a, " ")
 					if got == expected[8:] {
 						foundAThread = true

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -28,7 +28,7 @@ func NewCallback(fn any) uintptr {
 	ty := reflect.TypeOf(fn)
 	for i := range ty.NumIn() {
 		in := ty.In(i)
-		if !in.AssignableTo(reflect.TypeOf(CDecl{})) {
+		if !in.AssignableTo(reflect.TypeFor[CDecl]()) {
 			continue
 		}
 		if i != 0 {


### PR DESCRIPTION
# What issue is this addressing?
None; no issue filed.

## What _type_ of issue is this addressing?
Neither bug, feature, nor security: a maintenance/cleanup change.

## What this PR does | solves
Go 1.27's `go fix` rewrites constructs that newer standard library APIs express better. Running it over every GOOS/GOARCH this module builds for turns up three sites, all mechanical:

- `compareStatus` walks the lines of a `/proc` status file, so the slice from `strings.Split` only exists to be ranged over; `SplitSeq` yields the same lines without materializing it.
- The same function sorts a field list with `sort.Slice` and a less function that is plain string comparison, which is what `slices.Sort` does for an ordered element type.
- `NewCallback` asks whether an argument is assignable to `CDecl`, a type known at compile time, so `reflect.TypeFor` names it directly instead of building a value to take the type of.

`go fix` only analyzes the files selected by the current build constraints, so it was run for each of darwin, linux, freebsd, netbsd, windows, android, ios and js across the architectures purego supports, with cgo both on and off, plus the `faketime` tag. Only the two files here reported anything.

The cgo-enabled cross builds could not be analyzed on the machine this ran on, which has no cross C toolchain; darwin/amd64 and darwin/arm64 with cgo were covered and reported nothing.

Verified with `gofmt -l -s` (clean), `go vet` for linux and windows, `go build` for windows, and `go test ./...` on darwin/arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)