### PR TITLE
purego: only expand []any for declared variadic signatures

### DIFF
--- a/callback_test.go
+++ b/callback_test.go
@@ -411,3 +411,51 @@ func TestCallbackFloat32StackPacking(t *testing.T) {
 		t.Errorf("callCallback12Float32() = %d, want %d", got, want)
 	}
 }
+
+func TestRegisterFuncExpandFinalAnyArgument(t *testing.T) {
+	// The last argument is expanded into the C arguments held in it,
+	// whether it is declared as ...any or as []any.
+	// https://github.com/ebitengine/purego/issues/506
+	cb := purego.NewCallback(func(a, b, c uintptr) uintptr {
+		return a*100 + b*10 + c
+	})
+	const want = uintptr(123)
+	t.Run("Variadic", func(t *testing.T) {
+		var fn func(a uintptr, args ...any) uintptr
+		purego.RegisterFunc(&fn, cb)
+		if got := fn(1, uintptr(2), uintptr(3)); got != want {
+			t.Errorf("func(uintptr, ...any) = %d, want %d", got, want)
+		}
+	})
+	t.Run("Slice", func(t *testing.T) {
+		var fn func(a uintptr, args []any) uintptr
+		purego.RegisterFunc(&fn, cb)
+		if got := fn(1, []any{uintptr(2), uintptr(3)}); got != want {
+			t.Errorf("func(uintptr, []any) = %d, want %d", got, want)
+		}
+	})
+}
+
+func TestRegisterFuncKeepNonFinalAnyArgument(t *testing.T) {
+	// A []any that isn't the last argument is a regular argument:
+	// it is passed as one value and must not panic.
+	// https://github.com/ebitengine/purego/issues/506
+	var first any
+	var second uintptr
+	cb := purego.NewCallback(func(args *any, b uintptr) uintptr {
+		first = *args
+		second = b
+		return 0
+	})
+	var fn func(args []any, b uintptr) uintptr
+	purego.RegisterFunc(&fn, cb)
+	s := []any{uintptr(2), uintptr(3)}
+	fn(s, 7)
+	runtime.KeepAlive(s)
+	if want := any(uintptr(2)); first != want {
+		t.Errorf("the first C argument = %v, want %v", first, want)
+	}
+	if second != 7 {
+		t.Errorf("the second C argument = %d, want 7", second)
+	}
+}

--- a/callback_test.go
+++ b/callback_test.go
@@ -414,8 +414,7 @@ func TestCallbackFloat32StackPacking(t *testing.T) {
 
 func TestRegisterFuncExpandFinalAnyArgument(t *testing.T) {
 	// The last argument is expanded into the C arguments held in it,
-	// whether it is declared as ...any or as []any.
-	// https://github.com/ebitengine/purego/issues/506
+	// whether it is declared as ...any or as []any (#506).
 	cb := purego.NewCallback(func(a, b, c uintptr) uintptr {
 		return a*100 + b*10 + c
 	})
@@ -438,8 +437,7 @@ func TestRegisterFuncExpandFinalAnyArgument(t *testing.T) {
 
 func TestRegisterFuncKeepNonFinalAnyArgument(t *testing.T) {
 	// A []any that isn't the last argument is a regular argument:
-	// it is passed as one value and must not panic.
-	// https://github.com/ebitengine/purego/issues/506
+	// it is passed as one value and must not panic (#506).
 	var first any
 	var second uintptr
 	cb := purego.NewCallback(func(args *any, b uintptr) uintptr {

--- a/func.go
+++ b/func.go
@@ -342,14 +342,17 @@ func RegisterFunc(fptr any, cfn uintptr) {
 			}
 		}
 		for i, v := range args {
-			if variadic, ok := reflect.TypeAssert[[]any](args[i]); ok {
-				if i != len(args)-1 {
-					panic("purego: can only expand last parameter")
+			// Only splat a []any value when the declared signature is
+			// variadic and this is its final parameter. A []any in any
+			// other position is an ordinary single argument holding a
+			// slice, and must go through addValue as one pointer.
+			if ty.IsVariadic() && i == len(args)-1 {
+				if variadic, ok := reflect.TypeAssert[[]any](args[i]); ok {
+					for _, x := range variadic {
+						keepAlive = addValue(reflect.ValueOf(x), keepAlive, addInt, addFloat, addStack, &numInts, &numFloats, &numStack)
+					}
+					continue
 				}
-				for _, x := range variadic {
-					keepAlive = addValue(reflect.ValueOf(x), keepAlive, addInt, addFloat, addStack, &numInts, &numFloats, &numStack)
-				}
-				continue
 			}
 			// Check if we need to start Darwin ARM64 C-style stack packing
 			if runtime.GOARCH == "arm64" && isDarwin && shouldBundleStackArgs(v, numInts, numFloats) {

--- a/func.go
+++ b/func.go
@@ -73,11 +73,11 @@ func RegisterLibFunc(fptr any, handle uintptr, name string) {
 //	unsafe.Pointer, *T <=> void*
 //	[]T => void*
 //
-// There is a special case when the last argument of fptr is a variadic interface (or []interface{}):
+// There is a special case when the last argument of fptr is a variadic interface (or []any):
 // it will be expanded into a call to the C function as if it had the arguments in that slice.
 // This means that using arg ...any is like a cast to the function with the arguments inside arg.
 // This is not the same as C variadic.
-// Only the last argument is expanded this way. A []interface{} in any other position is an ordinary
+// Only the last argument is expanded this way. A []any in any other position is an ordinary
 // argument and is passed as a single value like any other slice.
 //
 // # Memory

--- a/func.go
+++ b/func.go
@@ -73,10 +73,12 @@ func RegisterLibFunc(fptr any, handle uintptr, name string) {
 //	unsafe.Pointer, *T <=> void*
 //	[]T => void*
 //
-// There is a special case when the last argument of fptr is a variadic interface (or []interface}
+// There is a special case when the last argument of fptr is a variadic interface (or []interface{}):
 // it will be expanded into a call to the C function as if it had the arguments in that slice.
 // This means that using arg ...any is like a cast to the function with the arguments inside arg.
 // This is not the same as C variadic.
+// Only the last argument is expanded this way. A []interface{} in any other position is an ordinary
+// argument and is passed as a single value like any other slice.
 //
 // # Memory
 //
@@ -342,11 +344,11 @@ func RegisterFunc(fptr any, cfn uintptr) {
 			}
 		}
 		for i, v := range args {
-			// Only splat a []any value when the declared signature is
-			// variadic and this is its final parameter. A []any in any
-			// other position is an ordinary single argument holding a
-			// slice, and must go through addValue as one pointer.
-			if ty.IsVariadic() && i == len(args)-1 {
+			// Only the last argument is expanded into several C arguments.
+			// Both a declared ...any parameter and a final []any parameter
+			// arrive here as a []any holding those arguments. A []any in any
+			// other position is an ordinary argument that is passed as one value.
+			if i == len(args)-1 {
 				if variadic, ok := reflect.TypeAssert[[]any](args[i]); ok {
 					for _, x := range variadic {
 						keepAlive = addValue(reflect.ValueOf(x), keepAlive, addInt, addFloat, addStack, &numInts, &numFloats, &numStack)


### PR DESCRIPTION
# What issue is this addressing?
#506

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The call closure splatted any []any-typed value appearing in the arguments, without consulting the declared signature. Non-variadic functions taking a []any parameter received splatted C arguments (or panicked with 'can only expand last parameter' when the slice was not last). Gate the expansion on ty.IsVariadic() and the final position so a []any elsewhere travels as a single slice pointer.

Closes #506
