### PR TITLE
objc: anchor ivarRegex so malformed names are rejected

### DIFF
--- a/objc/objc_runtime_darwin.go
+++ b/objc/objc_runtime_darwin.go
@@ -269,7 +269,7 @@ type FieldDef struct {
 }
 
 // ivarRegex checks to make sure the Ivar is correctly formatted
-var ivarRegex = regexp.MustCompile("[a-z_][a-zA-Z0-9_]*")
+var ivarRegex = regexp.MustCompile(`^[a-z_][a-zA-Z0-9_]*$`)
 
 // RegisterClass takes the name of the class to create, the superclass, a list of protocols this class
 // implements, a list of fields this class has and a list of methods. It returns the created class or an error


### PR DESCRIPTION
# What issue is this addressing?
#508

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
MatchString does substring matching, so the unanchored pattern let names like Bar or 'foo bar' through RegisterClass validation. Anchor it for a full-string match.

Closes #508