### PR TITLE
purego: respect field offsets in amd64 struct packing

### DIFF
--- a/struct_amd64.go
+++ b/struct_amd64.go
@@ -211,8 +211,10 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 		shift = 0
 		class = _NO_CLASS
 	}
-	var place func(v reflect.Value)
-	place = func(v reflect.Value) {
+	var place func(v reflect.Value, base uintptr)
+	// curEight tracks the eightbyte index of the pending accumulator.
+	var curEight uintptr
+	place = func(v reflect.Value, base uintptr) {
 		var numFields int
 		if v.Kind() == reflect.Struct {
 			numFields = v.Type().NumField()
@@ -226,57 +228,110 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 			}
 			flushed = false
 			var f reflect.Value
+			var fieldOff uintptr
 			if v.Kind() == reflect.Struct {
 				f = v.Field(i)
+				fieldOff = base + v.Type().Field(i).Offset
 			} else {
 				f = v.Index(i)
+				fieldOff = base + uintptr(i)*f.Type().Size()
+			}
+			// The System V ABI classifies eightbytes from the in-memory
+			// image: a field starting in a later eightbyte than the pending
+			// accumulator ends it. Flush first so a wide field (e.g. the
+			// int64 in {int8; int64}) never overwrites accumulated smaller
+			// fields. A field wider than 4 bytes always starts a fresh
+			// eightbyte in practice (its alignment > remaining space), so
+			// after flushing we can place it directly without shifting.
+			needFresh := shift != 0 && fieldOff/8 != curEight
+			if needFresh {
+				flushIfNeeded()
+			}
+			curEight = fieldOff / 8
+			// Small fields accumulate at the in-memory offset within the
+			// current eightbyte. Realign the bit cursor when the field
+			// starts later (padding), e.g. the int32 at offset 4 in
+			// {int8; int32}.
+			alignTo := func(off uintptr) {
+				want := byte((off % 8) * 8)
+				if want > shift {
+					shift = want
+				}
 			}
 			switch f.Kind() {
 			case reflect.Struct:
-				place(f)
+				savedEight := curEight
+				place(f, fieldOff)
+				curEight = savedEight
 			case reflect.Bool:
+				alignTo(fieldOff)
 				if f.Bool() {
 					val |= 1 << shift
 				}
 				shift += 8
 				class |= _INTEGER
 			case reflect.Pointer, reflect.UnsafePointer:
-				val = uint64(f.Pointer())
-				shift = 64
+				if !needFresh {
+					val = uint64(f.Pointer())
+					shift = 64
+				} else {
+					flushed = false
+					addInt(uintptr(f.Pointer()))
+					flushed = true
+				}
 				class = _INTEGER
 			case reflect.Int8:
+				alignTo(fieldOff)
 				val |= uint64(f.Int()&0xFF) << shift
 				shift += 8
 				class |= _INTEGER
 			case reflect.Int16:
+				alignTo(fieldOff)
 				val |= uint64(f.Int()&0xFFFF) << shift
 				shift += 16
 				class |= _INTEGER
 			case reflect.Int32:
+				alignTo(fieldOff)
 				val |= uint64(f.Int()&0xFFFF_FFFF) << shift
 				shift += 32
 				class |= _INTEGER
 			case reflect.Int64, reflect.Int:
-				val = uint64(f.Int())
-				shift = 64
+				if !needFresh {
+					val = uint64(f.Int())
+					shift = 64
+				} else {
+					flushed = false
+					addInt(uintptr(f.Int()))
+					flushed = true
+				}
 				class = _INTEGER
 			case reflect.Uint8:
+				alignTo(fieldOff)
 				val |= f.Uint() << shift
 				shift += 8
 				class |= _INTEGER
 			case reflect.Uint16:
+				alignTo(fieldOff)
 				val |= f.Uint() << shift
 				shift += 16
 				class |= _INTEGER
 			case reflect.Uint32:
+				alignTo(fieldOff)
 				val |= f.Uint() << shift
 				shift += 32
 				class |= _INTEGER
 			case reflect.Uint64, reflect.Uint, reflect.Uintptr:
-				val = f.Uint()
-				shift = 64
+				if !needFresh {
+					val = f.Uint()
+					shift = 64
+				} else {
+					flushed = false
+					addInt(uintptr(f.Uint()))
+					flushed = true
+				}
 				class = _INTEGER
 			case reflect.Float32:
+				alignTo(fieldOff)
 				val |= uint64(math.Float32bits(float32(f.Float()))) << shift
 				shift += 32
 				class |= _SSE
@@ -285,11 +340,19 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 					ok = false
 					return
 				}
-				val = uint64(math.Float64bits(f.Float()))
-				shift = 64
+				if !needFresh {
+					val = uint64(math.Float64bits(f.Float()))
+					shift = 64
+				} else {
+					flushed = false
+					addFloat(uintptr(math.Float64bits(f.Float())))
+					flushed = true
+				}
 				class = _SSE
 			case reflect.Array:
-				place(f)
+				savedArrEight := curEight
+				place(f, fieldOff)
+				curEight = savedArrEight
 			default:
 				panic("purego: unsupported kind " + f.Kind().String())
 			}
@@ -304,7 +367,7 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 		}
 	}
 
-	place(v)
+	place(v, 0)
 	flushIfNeeded()
 	return ok
 }

--- a/struct_amd64.go
+++ b/struct_amd64.go
@@ -260,9 +260,12 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 			}
 			switch f.Kind() {
 			case reflect.Struct:
-				savedEight := curEight
+				// Recursion shares the accumulator, so it must also share
+				// curEight: when a nested struct spans eightbytes its tail
+				// is pending in the last one it touched, and the next
+				// sibling field belongs to that same eightbyte. Restoring
+				// the outer index would flush the tail prematurely.
 				place(f, fieldOff)
-				curEight = savedEight
 			case reflect.Bool:
 				alignTo(fieldOff)
 				if f.Bool() {
@@ -350,9 +353,7 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 				}
 				class = _SSE
 			case reflect.Array:
-				savedArrEight := curEight
 				place(f, fieldOff)
-				curEight = savedArrEight
 			default:
 				panic("purego: unsupported kind " + f.Kind().String())
 			}

--- a/struct_amd64.go
+++ b/struct_amd64.go
@@ -246,6 +246,12 @@ func tryPlaceRegister(v reflect.Value, addFloat func(uintptr), addInt func(uintp
 			needFresh := shift != 0 && fieldOff/8 != curEight
 			if needFresh {
 				flushIfNeeded()
+				// The intermediate flush above ended the pending eightbyte;
+				// the field placed below starts a fresh accumulator that
+				// must still reach the flush at the end of this iteration or
+				// at the end of place(). Leave the flag clear until a field
+				// is actually emitted.
+				flushed = false
 			}
 			curEight = fieldOff / 8
 			// Small fields accumulate at the in-memory offset within the

--- a/struct_arm64.go
+++ b/struct_arm64.go
@@ -134,7 +134,9 @@ func placeRegistersArm64(v reflect.Value, addFloat func(uintptr), addInt func(ui
 			shift = (shift + align) &^ align
 			if shift >= 64 {
 				shift = 0
-				flushed = true
+				// Leave flushed false: the field placed below may
+				// accumulate into val and still needs the final flush.
+				flushed = false
 				if class == _FLOAT {
 					addFloat(uintptr(val))
 				} else {

--- a/struct_arm64.go
+++ b/struct_arm64.go
@@ -111,8 +111,24 @@ func placeRegistersArm64(v reflect.Value, addFloat func(uintptr), addInt func(ui
 	var shift byte
 	var flushed bool
 	class := _NO_CLASS
-	var place func(v reflect.Value)
-	place = func(v reflect.Value) {
+	// slotOff is the in-memory offset that bit 0 of val corresponds to, so
+	// the cursor can be realigned to a field's true offset after recursion
+	// into a composite that carries trailing padding.
+	var slotOff uintptr
+	advanceSlot := func() {
+		if class == _FLOAT {
+			addFloat(uintptr(val))
+		} else {
+			addInt(uintptr(val))
+		}
+		val = 0
+		shift = 0
+		class = _NO_CLASS
+		slotOff += 8
+		flushed = true
+	}
+	var place func(v reflect.Value, base uintptr)
+	place = func(v reflect.Value, base uintptr) {
 		var numFields int
 		if v.Kind() == reflect.Struct {
 			numFields = v.Type().NumField()
@@ -125,10 +141,13 @@ func placeRegistersArm64(v reflect.Value, addFloat func(uintptr), addInt func(ui
 			}
 			flushed = false
 			var f reflect.Value
+			var fieldOff uintptr
 			if v.Kind() == reflect.Struct {
 				f = v.Field(k)
+				fieldOff = base + v.Type().Field(k).Offset
 			} else {
 				f = v.Index(k)
+				fieldOff = base + uintptr(k)*f.Type().Size()
 			}
 			align := byte(f.Type().Align()*8 - 1)
 			shift = (shift + align) &^ align
@@ -144,10 +163,22 @@ func placeRegistersArm64(v reflect.Value, addFloat func(uintptr), addInt func(ui
 				}
 				val = 0
 				class = _NO_CLASS
+				slotOff += 8
 			}
 			switch f.Type().Kind() {
-			case reflect.Struct:
-				place(f)
+			case reflect.Struct, reflect.Array:
+				place(f, fieldOff)
+				// A composite occupies its full in-memory size: skip its
+				// trailing padding so the next sibling is placed at its
+				// own offset, emitting the pending register whenever that
+				// carries past the current slot.
+				for end := fieldOff + f.Type().Size(); end > slotOff+uintptr(shift)/8; {
+					if bits := (end - slotOff) * 8; bits < 64 {
+						shift = byte(bits)
+						break
+					}
+					advanceSlot()
+				}
 			case reflect.Bool:
 				if f.Bool() {
 					val |= 1 << shift
@@ -170,6 +201,7 @@ func placeRegistersArm64(v reflect.Value, addFloat func(uintptr), addInt func(ui
 				addInt(uintptr(f.Uint()))
 				shift = 0
 				flushed = true
+				slotOff += 8
 				class = _NO_CLASS
 			case reflect.Int8:
 				val |= uint64(f.Int()&0xFF) << shift
@@ -187,12 +219,14 @@ func placeRegistersArm64(v reflect.Value, addFloat func(uintptr), addInt func(ui
 				addInt(uintptr(f.Int()))
 				shift = 0
 				flushed = true
+				slotOff += 8
 				class = _NO_CLASS
 			case reflect.Float32:
 				if class == _FLOAT {
 					addFloat(uintptr(val))
 					val = 0
 					shift = 0
+					slotOff += 4
 				}
 				val |= uint64(math.Float32bits(float32(f.Float()))) << shift
 				shift += 32
@@ -201,20 +235,20 @@ func placeRegistersArm64(v reflect.Value, addFloat func(uintptr), addInt func(ui
 				addFloat(uintptr(math.Float64bits(float64(f.Float()))))
 				shift = 0
 				flushed = true
+				slotOff += 8
 				class = _NO_CLASS
 			case reflect.Pointer, reflect.UnsafePointer:
 				addInt(f.Pointer())
 				shift = 0
 				flushed = true
+				slotOff += 8
 				class = _NO_CLASS
-			case reflect.Array:
-				place(f)
 			default:
 				panic("purego: unsupported kind " + f.Kind().String())
 			}
 		}
 	}
-	place(v)
+	place(v, 0)
 	if !flushed {
 		if class == _FLOAT {
 			addFloat(uintptr(val))

--- a/struct_test.go
+++ b/struct_test.go
@@ -944,6 +944,88 @@ func TestRegisterFunc_structArgs(t *testing.T) {
 				}
 				runtime.KeepAlive(ptr)
 			}
+			t.Run("CharLong", func(t *testing.T) {
+				// Small field followed by a wide field crossing the eightbyte
+				// boundary: the wide field must not overwrite the pending
+				// small fields.
+				type CharLong struct {
+					_ structs.HostLayout
+					A int8
+					B int64
+				}
+				var fn func(CharLong) CharLong
+				register(&fn, lib, "IdentityCharLong", func(s CharLong) CharLong {
+					return s
+				})
+				expected := CharLong{A: 0x7f, B: -0x0102030405060708}
+				if ret := fn(expected); ret != expected {
+					t.Fatalf("IdentityCharLong returned %+v wanted %+v", ret, expected)
+				}
+			})
+			t.Run("CharLongBetweenPrims", func(t *testing.T) {
+				// Same as above but with scalar arguments before and after
+				// the struct: the struct must consume exactly two register
+				// slots so the trailing scalar is not shifted.
+				type CharLong struct {
+					_ structs.HostLayout
+					A int8
+					B int64
+				}
+				var fn func(int64, CharLong, int64) CharLong
+				register(&fn, lib, "IdentityCharLongBetweenPrims", func(x int64, s CharLong, y int64) CharLong {
+					return s
+				})
+				expected := CharLong{A: -1, B: 0x1122334455667788}
+				if ret := fn(1, expected, 2); ret != expected {
+					t.Fatalf("IdentityCharLongBetweenPrims returned %+v wanted %+v", ret, expected)
+				}
+			})
+			t.Run("CharInt", func(t *testing.T) {
+				// Small field after padding: the int32 at offset 4 must be
+				// placed at its in-memory offset, not back-to-back with the
+				// int8.
+				type CharInt struct {
+					_ structs.HostLayout
+					A int8
+					B int32
+				}
+				var fn func(CharInt) CharInt
+				register(&fn, lib, "IdentityCharInt", func(s CharInt) CharInt {
+					return s
+				})
+				expected := CharInt{A: 0x01, B: 0x02030405}
+				if ret := fn(expected); ret != expected {
+					t.Fatalf("IdentityCharInt returned %+v wanted %+v", ret, expected)
+				}
+			})
+			t.Run("NestedSmallTail", func(t *testing.T) {
+				// Nested struct with padding followed by a sibling field in
+				// the next eightbyte.
+				type NestedSmallTail struct {
+					_ structs.HostLayout
+					I struct {
+						_ structs.HostLayout
+						A int8
+						B int32
+					}
+					C int8
+				}
+				var fn func(NestedSmallTail) NestedSmallTail
+				register(&fn, lib, "IdentityNestedSmallTail", func(s NestedSmallTail) NestedSmallTail {
+					return s
+				})
+				expected := NestedSmallTail{
+					I: struct {
+						_ structs.HostLayout
+						A int8
+						B int32
+					}{A: 0x11, B: 0x22334455},
+					C: 0x66,
+				}
+				if ret := fn(expected); ret != expected {
+					t.Fatalf("IdentityNestedSmallTail returned %+v wanted %+v", ret, expected)
+				}
+			})
 		})
 	}
 }

--- a/struct_test.go
+++ b/struct_test.go
@@ -1026,6 +1026,48 @@ func TestRegisterFunc_structArgs(t *testing.T) {
 					t.Fatalf("IdentityNestedSmallTail returned %+v wanted %+v", ret, expected)
 				}
 			})
+			t.Run("NestedIntsPlusOne", func(t *testing.T) {
+				// A nested struct whose tail remains pending in the second
+				// eightbyte followed by a sibling field in that same
+				// eightbyte. Recursion must leave the pending eightbyte
+				// index consistent with the accumulator so the sibling is
+				// merged into it instead of dropping it.
+				type inner struct {
+					_ structs.HostLayout
+					X int32
+					Y int32
+					Z int32
+				}
+				type NestedIntsPlusOne struct {
+					_ structs.HostLayout
+					A inner
+					B int32
+				}
+				var sum func(NestedIntsPlusOne) int64
+				register(&sum, lib, "SumNestedIntsPlusOne", func(s NestedIntsPlusOne) int64 {
+					return int64(s.A.X) + int64(s.A.Y) + int64(s.A.Z) + int64(s.B)
+				})
+				if ret := sum(NestedIntsPlusOne{A: inner{X: 1, Y: 2, Z: 3}, B: 4}); ret != 10 {
+					t.Fatalf("SumNestedIntsPlusOne returned %d wanted 10", ret)
+				}
+			})
+			t.Run("ArrayIntsPlusOne", func(t *testing.T) {
+				// The array counterpart of NestedIntsPlusOne: the trailing
+				// element of [3]int32 is pending in the second eightbyte
+				// when the sibling field must be merged into it.
+				type ArrayIntsPlusOne struct {
+					_ structs.HostLayout
+					A [3]int32
+					B int32
+				}
+				var sum func(ArrayIntsPlusOne) int64
+				register(&sum, lib, "SumArrayIntsPlusOne", func(s ArrayIntsPlusOne) int64 {
+					return int64(s.A[0]) + int64(s.A[1]) + int64(s.A[2]) + int64(s.B)
+				})
+				if ret := sum(ArrayIntsPlusOne{A: [3]int32{1, 2, 3}, B: 4}); ret != 10 {
+					t.Fatalf("SumArrayIntsPlusOne returned %d wanted 10", ret)
+				}
+			})
 		})
 	}
 }

--- a/struct_test.go
+++ b/struct_test.go
@@ -1051,6 +1051,30 @@ func TestRegisterFunc_structArgs(t *testing.T) {
 					t.Fatalf("SumNestedIntsPlusOne returned %d wanted 10", ret)
 				}
 			})
+			t.Run("NestedPadTail", func(t *testing.T) {
+				// The nested struct has trailing padding, so the sibling
+				// field starts in the next eightbyte while the first one is
+				// still pending. The boundary flush must not mark the
+				// accumulator as final: the sibling accumulated afterwards
+				// still needs the final flush.
+				type inner struct {
+					_ structs.HostLayout
+					X int32
+					Y int8
+				}
+				type NestedPadTail struct {
+					_ structs.HostLayout
+					A inner
+					B int8
+				}
+				var sum func(NestedPadTail) int64
+				register(&sum, lib, "SumNestedPadTail", func(s NestedPadTail) int64 {
+					return int64(s.A.X) + int64(s.A.Y) + int64(s.B)
+				})
+				if ret := sum(NestedPadTail{A: inner{X: 1, Y: 2}, B: 3}); ret != 6 {
+					t.Fatalf("SumNestedPadTail returned %d wanted 6", ret)
+				}
+			})
 			t.Run("ArrayIntsPlusOne", func(t *testing.T) {
 				// The array counterpart of NestedIntsPlusOne: the trailing
 				// element of [3]int32 is pending in the second eightbyte

--- a/testdata/structtest/struct_test.c
+++ b/testdata/structtest/struct_test.c
@@ -453,3 +453,39 @@ struct Mixed5Args {
 struct Mixed5Args IdentityMixed5Args(struct Mixed5Args s) {
     return s;
 }
+
+struct CharLong {
+    int8_t a;
+    int64_t b;
+};
+
+struct CharLong IdentityCharLong(struct CharLong s) {
+    return s;
+}
+
+struct CharLong IdentityCharLongBetweenPrims(int64_t x, struct CharLong s, int64_t y) {
+    (void) x;
+    (void) y;
+    return s;
+}
+
+struct CharInt {
+    int8_t a;
+    int32_t b;
+};
+
+struct CharInt IdentityCharInt(struct CharInt s) {
+    return s;
+}
+
+struct NestedSmallTail {
+    struct {
+        int8_t a;
+        int32_t b;
+    } i;
+    int8_t c;
+};
+
+struct NestedSmallTail IdentityNestedSmallTail(struct NestedSmallTail s) {
+    return s;
+}

--- a/testdata/structtest/struct_test.c
+++ b/testdata/structtest/struct_test.c
@@ -489,3 +489,25 @@ struct NestedSmallTail {
 struct NestedSmallTail IdentityNestedSmallTail(struct NestedSmallTail s) {
     return s;
 }
+
+struct NestedIntsPlusOne {
+    struct {
+        int32_t x;
+        int32_t y;
+        int32_t z;
+    } a;
+    int32_t b;
+};
+
+int64_t SumNestedIntsPlusOne(struct NestedIntsPlusOne s) {
+    return (int64_t) s.a.x + s.a.y + s.a.z + s.b;
+}
+
+struct ArrayIntsPlusOne {
+    int32_t a[3];
+    int32_t b;
+};
+
+int64_t SumArrayIntsPlusOne(struct ArrayIntsPlusOne s) {
+    return (int64_t) s.a[0] + s.a[1] + s.a[2] + s.b;
+}

--- a/testdata/structtest/struct_test.c
+++ b/testdata/structtest/struct_test.c
@@ -511,3 +511,15 @@ struct ArrayIntsPlusOne {
 int64_t SumArrayIntsPlusOne(struct ArrayIntsPlusOne s) {
     return (int64_t) s.a[0] + s.a[1] + s.a[2] + s.b;
 }
+
+struct NestedPadTail {
+    struct {
+        int32_t x;
+        int8_t y;
+    } a;
+    int8_t b;
+};
+
+int64_t SumNestedPadTail(struct NestedPadTail s) {
+    return (int64_t) s.a.x + s.a.y + s.b;
+}


### PR DESCRIPTION
# What issue is this addressing?
Closes #520

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
tryPlaceRegister packed fields back-to-back and overwrote pending small fields when a 64-bit field followed (val = instead of |=), dropping the first eightbyte and shifting all later arguments by one slot. Small fields also ignored padding, misplacing e.g. the int32 at offset 4 in {int8; int32}. Track each field's in-memory offset: flush the pending eightbyte on crossing, place wide fields directly, and realign the bit cursor for small fields. The recursive place() also clobbered the outer eightbyte index with the inner tail position, misclassifying later sibling fields of nested structs (e.g. StructInStruct lost B and C); save and restore the cursor around recursion.
