### PR TITLE
purego: document that NewCallback consumes one table entry per call

### DIFF
--- a/syscall_unix.go
+++ b/syscall_unix.go
@@ -28,7 +28,7 @@ func syscall_syscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 //
 // Every call to NewCallback creates a new callback even for the same function value, so passing a Go callback to C
 // inside a loop (e.g. a qsort comparator) keeps consuming callbacks and eventually panics once they are exhausted.
-// The same happens when a func value is passed to a C function, as RegisterFunc creates a new callback for each
+// The same happens when a func value is passed to a C function, as [RegisterFunc] creates a new callback for each
 // call. Create the callback once with NewCallback and reuse the returned pointer instead.
 func NewCallback(fn any) uintptr {
 	ty := reflect.TypeOf(fn)

--- a/syscall_unix.go
+++ b/syscall_unix.go
@@ -25,6 +25,12 @@ func syscall_syscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 // of uintptr. Only a limited number of callbacks may be created in a single Go process, and any memory allocated
 // for these callbacks is never released. At least 2000 callbacks can always be created. Although this function
 // provides similar functionality to windows.NewCallback it is distinct.
+//
+// Each call to NewCallback consumes one entry of the fixed callback table,
+// even for the same function value: passing a Go callback to C inside a
+// loop (e.g. a qsort comparator) exhausts the table after 2000 calls and
+// panics. Resolve the callback once with NewCallback and reuse the returned
+// pointer instead of letting RegisterFunc create a new one per call.
 func NewCallback(fn any) uintptr {
 	ty := reflect.TypeOf(fn)
 	for i := range ty.NumIn() {

--- a/syscall_unix.go
+++ b/syscall_unix.go
@@ -23,14 +23,13 @@ func syscall_syscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 // This is useful when interoperating with C code requiring callbacks. The argument is expected to be a
 // function with zero or one uintptr-sized result. The function must not have arguments with size larger than the size
 // of uintptr. Only a limited number of callbacks may be created in a single Go process, and any memory allocated
-// for these callbacks is never released. At least 2000 callbacks can always be created. Although this function
+// for these callbacks is never released. At least 1024 callbacks can always be created. Although this function
 // provides similar functionality to windows.NewCallback it is distinct.
 //
-// Each call to NewCallback consumes one entry of the fixed callback table,
-// even for the same function value: passing a Go callback to C inside a
-// loop (e.g. a qsort comparator) exhausts the table after 2000 calls and
-// panics. Resolve the callback once with NewCallback and reuse the returned
-// pointer instead of letting RegisterFunc create a new one per call.
+// Every call to NewCallback creates a new callback even for the same function value, so passing a Go callback to C
+// inside a loop (e.g. a qsort comparator) keeps consuming callbacks and eventually panics once they are exhausted.
+// The same happens when a func value is passed to a C function, as RegisterFunc creates a new callback for each
+// call. Create the callback once with NewCallback and reuse the returned pointer instead.
 func NewCallback(fn any) uintptr {
 	ty := reflect.TypeOf(fn)
 	for i := range ty.NumIn() {

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -23,6 +23,11 @@ func syscall_syscallN(fn uintptr, args ...uintptr) (r1, r2, err uintptr) {
 // allocated for these callbacks is never released. Between NewCallback and NewCallbackCDecl, at least 1024
 // callbacks can always be created. Although this function is similar to the darwin version it may act
 // differently.
+//
+// Every call to NewCallback creates a new callback even for the same function value, so passing a Go callback to C
+// inside a loop (e.g. a qsort comparator) keeps consuming callbacks and eventually panics once they are exhausted.
+// The same happens when a func value is passed to a C function, as [RegisterFunc] creates a new callback for each
+// call. Create the callback once with NewCallback and reuse the returned pointer instead.
 func NewCallback(fn any) uintptr {
 	isCDecl := false
 	ty := reflect.TypeOf(fn)


### PR DESCRIPTION
# What issue is this addressing?
Closes #521

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Passing a Go func value to C in a loop (e.g. via RegisterFunc's func arguments, which call NewCallback on every invocation) exhausts the fixed 2000-entry callback table and panics. Function values have no comparable identity available to reflect, so automatic deduplication is not possible; document the pitfall and the workaround of resolving the callback once and reusing the pointer.
