### PR TITLE
purego: pass non-HFA arm64 structs in integer registers

### DIFF
--- a/struct_arm64.go
+++ b/struct_arm64.go
@@ -89,6 +89,13 @@ func addStruct(v reflect.Value, numInts, numFloats, numStack *int, addInt, addFl
 			*numFloats = numOfFloatRegisters()
 		} else if hva && *numInts+numABIFields(v.Type()) > numOfIntegerRegisters() {
 			*numInts = numOfIntegerRegisters()
+		} else if !hfa && !hva && !isDarwin && *numInts+int(roundUpTo8(size)/8) > numOfIntegerRegisters() {
+			// A non-HFA/HVA composite packed into integer registers is
+			// passed entirely on the stack when the remaining integer
+			// registers cannot hold all of its eightbytes (AAPCS64;
+			// mirrors getCallbackStruct). Darwin may instead split it
+			// between registers and the stack.
+			*numInts = numOfIntegerRegisters()
 		}
 
 		placeRegisters(v, addFloat, addInt)

--- a/struct_arm64.go
+++ b/struct_arm64.go
@@ -107,6 +107,35 @@ func placeRegisters(v reflect.Value, addFloat func(uintptr), addInt func(uintptr
 }
 
 func placeRegistersArm64(v reflect.Value, addFloat func(uintptr), addInt func(uintptr)) {
+	// Non-HFA composites of 16 bytes or less are passed packed into
+	// 1-2 general-purpose registers (AAPCS64 C.7; mirrors
+	// getCallbackStruct). Copy the in-memory image eightbyte by
+	// eightbyte instead of routing members by kind, so mixed structs
+	// such as {int64; float64} land in x0/x1 rather than x0/v0.
+	if !isHFA(v.Type()) && !isHVA(v.Type()) && v.Type().Size() <= 16 {
+		if !v.CanAddr() {
+			tmp := reflect.New(v.Type()).Elem()
+			tmp.Set(v)
+			v = tmp
+		}
+		ptr := v.Addr().UnsafePointer()
+		size := v.Type().Size()
+		for off := uintptr(0); off < size; off += 8 {
+			var chunk uintptr
+			if remaining := size - off; remaining >= 8 {
+				chunk = *(*uintptr)(unsafe.Add(ptr, off))
+			} else {
+				// Final partial chunk: read byte-by-byte to avoid
+				// reading beyond the value's allocation.
+				for i := range remaining {
+					b := *(*byte)(unsafe.Add(ptr, off+i))
+					chunk |= uintptr(b) << (i * 8)
+				}
+			}
+			addInt(chunk)
+		}
+		return
+	}
 	var val uint64
 	var shift byte
 	var flushed bool

--- a/struct_arm64.go
+++ b/struct_arm64.go
@@ -91,10 +91,12 @@ func addStruct(v reflect.Value, numInts, numFloats, numStack *int, addInt, addFl
 			*numInts = numOfIntegerRegisters()
 		} else if !hfa && !hva && !isDarwin && *numInts+int(roundUpTo8(size)/8) > numOfIntegerRegisters() {
 			// A non-HFA/HVA composite packed into integer registers is
-			// passed entirely on the stack when the remaining integer
-			// registers cannot hold all of its eightbytes (AAPCS64;
-			// mirrors getCallbackStruct). Darwin may instead split it
-			// between registers and the stack.
+			// passed entirely on the stack, consuming the remaining
+			// integer registers, when they cannot hold all of its
+			// eightbytes (AAPCS64; mirrors getCallbackStruct). Darwin
+			// enforces the same all-or-nothing rule earlier, in the
+			// stack-argument bundling path (see shouldBundleStackArgs),
+			// so there is nothing to do here.
 			*numInts = numOfIntegerRegisters()
 		}
 

--- a/struct_arm64.go
+++ b/struct_arm64.go
@@ -127,22 +127,7 @@ func placeRegistersArm64(v reflect.Value, addFloat func(uintptr), addInt func(ui
 			tmp.Set(v)
 			v = tmp
 		}
-		ptr := v.Addr().UnsafePointer()
-		size := v.Type().Size()
-		for off := uintptr(0); off < size; off += 8 {
-			var chunk uintptr
-			if remaining := size - off; remaining >= 8 {
-				chunk = *(*uintptr)(unsafe.Add(ptr, off))
-			} else {
-				// Final partial chunk: read byte-by-byte to avoid
-				// reading beyond the value's allocation.
-				for i := range remaining {
-					b := *(*byte)(unsafe.Add(ptr, off+i))
-					chunk |= uintptr(b) << (i * 8)
-				}
-			}
-			addInt(chunk)
-		}
+		copyStruct8ByteChunks(v.Addr().UnsafePointer(), v.Type().Size(), addInt)
 		return
 	}
 	var val uint64
@@ -348,12 +333,14 @@ func isHVA(t reflect.Type) bool {
 	}
 }
 
-// copyStruct8ByteChunks copies struct memory in 8-byte chunks to the provided callback.
-// This is used for Darwin ARM64's byte-level packing of non-HFA/HVA structs.
+// copyStruct8ByteChunks copies struct memory in 8-byte chunks to the provided
+// callback. The final partial chunk is read byte-by-byte so that nothing beyond
+// the value's allocation is touched, and is zero-extended.
+//
+// Both Darwin ARM64's byte-level packing and the AAPCS64 rule for non-HFA/HVA
+// composites of 16 bytes or less pass such an argument as consecutive chunks of
+// its in-memory image, so the two paths share this helper.
 func copyStruct8ByteChunks(ptr unsafe.Pointer, size uintptr, addChunk func(uintptr)) {
-	if !isDarwin {
-		panic("purego: should only be called on darwin")
-	}
 	for offset := uintptr(0); offset < size; offset += 8 {
 		var chunk uintptr
 		remaining := size - offset

--- a/struct_test.go
+++ b/struct_test.go
@@ -853,6 +853,35 @@ func TestRegisterFunc_structArgs(t *testing.T) {
 					t.Fatalf("IdentityFloatAndInt returned %+v wanted %+v", ret, expected)
 				}
 			}
+			if runtime.GOARCH == "arm64" {
+				// Mixed int64 + float64: non-HFA, so it must be packed
+				// into x0/x1 instead of being split across x0/v0 (AAPCS64).
+				type Int64AndDouble struct {
+					_ structs.HostLayout
+					A int64
+					B float64
+				}
+				var fn func(Int64AndDouble) Int64AndDouble
+				register(&fn, lib, "IdentityInt64AndDouble", func(s Int64AndDouble) Int64AndDouble {
+					return s
+				})
+				expected := Int64AndDouble{A: -1234, B: 5.25}
+				if ret := fn(expected); ret != expected {
+					t.Fatalf("IdentityInt64AndDouble returned %+v wanted %+v", ret, expected)
+				}
+				if runtime.GOOS != "darwin" {
+					// Only one integer register is left, so the whole
+					// struct must go on the stack rather than being split
+					// between a register and the stack.
+					var fn func(int64, int64, int64, int64, int64, int64, int64, Int64AndDouble) Int64AndDouble
+					register(&fn, lib, "IdentityInt64AndDoubleAfterRegisters", func(a, b, c, d, e, f, g int64, s Int64AndDouble) Int64AndDouble {
+						return s
+					})
+					if ret := fn(1, 2, 3, 4, 5, 6, 7, expected); ret != expected {
+						t.Fatalf("IdentityInt64AndDoubleAfterRegisters returned %+v wanted %+v", ret, expected)
+					}
+				}
+			}
 			{
 				// Struct > 16 bytes: hidden pointer on amd64, pointer in int register on arm64.
 				type ThreeInt64 struct {

--- a/struct_test.go
+++ b/struct_test.go
@@ -869,10 +869,12 @@ func TestRegisterFunc_structArgs(t *testing.T) {
 				if ret := fn(expected); ret != expected {
 					t.Fatalf("IdentityInt64AndDouble returned %+v wanted %+v", ret, expected)
 				}
-				if runtime.GOOS != "darwin" {
-					// Only one integer register is left, so the whole
-					// struct must go on the stack rather than being split
-					// between a register and the stack.
+				{
+					// Only one integer register is left, so the whole struct
+					// must go on the stack rather than being split between
+					// a register and the stack. Darwin's ABI agrees: clang
+					// spills both eightbytes to the stack and consumes the
+					// remaining integer register.
 					var fn func(int64, int64, int64, int64, int64, int64, int64, Int64AndDouble) Int64AndDouble
 					register(&fn, lib, "IdentityInt64AndDoubleAfterRegisters", func(a, b, c, d, e, f, g int64, s Int64AndDouble) Int64AndDouble {
 						return s

--- a/testdata/structtest/struct_test.c
+++ b/testdata/structtest/struct_test.c
@@ -417,6 +417,19 @@ struct FloatAndInt IdentityFloatAndInt(struct FloatAndInt s) {
     return s;
 }
 
+struct Int64AndDouble {
+    int64_t a;
+    double b;
+};
+
+struct Int64AndDouble IdentityInt64AndDouble(struct Int64AndDouble s) {
+    return s;
+}
+
+struct Int64AndDouble IdentityInt64AndDoubleAfterRegisters(int64_t a, int64_t b, int64_t c, int64_t d, int64_t e, int64_t f, int64_t g, struct Int64AndDouble s) {
+    return s;
+}
+
 struct ThreeInt64 {
     int64_t a, b, c;
 };


### PR DESCRIPTION
# What issue is this addressing?
Closes #522

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
placeRegistersArm64 routed float/64-bit members straight to FP or integer registers by kind, so mixed structs such as {int64; float64} went out on x0/v0 while AAPCS64 (and our own getCallbackStruct) expect them packed into x0/x1. Copy the in-memory image eightbyte by eightbyte for non-HFA/HVA aggregates of 16 bytes or less.
