### PR TITLE
objc: create new blocks as stack blocks so Copy moves them

### DIFF
--- a/objc/objc_block_darwin.go
+++ b/objc/objc_block_darwin.go
@@ -19,7 +19,10 @@ const (
 	// when the reference count drops to zero, so the associated function is also unreferenced.
 
 	// blockBaseClass is the name of the class that block objects will be initialized with.
-	blockBaseClass = "__NSMallocBlock__"
+	// New blocks start on the stack so that Block_copy moves them to the
+	// heap; starting from __NSMallocBlock__ would make Copy a no-op retain
+	// of the Go-side allocation.
+	blockBaseClass = "__NSStackBlock__"
 	// blockFlags is the set of flags that block objects will be initialized with.
 	blockFlags = blockHasCopyDispose | blockHasSignature
 


### PR DESCRIPTION
# What issue is this addressing?
Closes #523

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
NewBlock built its template with an __NSMallocBlock__ isa, for which _Block_copy is a no-op retain of the Go-side allocation. The Block then points at Go memory invisible to the collector. Start from __NSStackBlock__ so Copy relocates the block to the heap as the ABI requires.
