### PR TITLE
purego: return 64-bit callback results on 386

### DIFF
--- a/callback_test.go
+++ b/callback_test.go
@@ -154,6 +154,51 @@ func TestNewCallbackFloat32AndFloat64(t *testing.T) {
 	}
 }
 
+func TestNewCallbackInt64Result(t *testing.T) {
+	// A 64-bit result needs two words: EDX:EAX on 386 and R1:R0 on arm.
+	// The trampoline must forward both halves of the value.
+	const mask = int64(0x0123456789abcdef)
+	imp := purego.NewCallback(func(v int64) int64 { return v ^ mask })
+	var fn func(v int64) int64
+	purego.RegisterFunc(&fn, imp)
+	for _, v := range []int64{
+		0,
+		-1,
+		1 << 32,
+		-0x7edcba9876543210,
+	} {
+		if got, want := fn(v), v^mask; got != want {
+			t.Errorf("callback(%#x) = %#x, want %#x", uint64(v), uint64(got), uint64(want))
+		}
+	}
+}
+
+func TestNewCallbackUint64Result(t *testing.T) {
+	// The upper half of a uint64 result must not be dropped by the trampoline.
+	imp := purego.NewCallback(func(lo, hi uint32) uint64 { return uint64(hi)<<32 | uint64(lo) })
+	var fn func(lo, hi uint32) uint64
+	purego.RegisterFunc(&fn, imp)
+	const want = uint64(0x0123456789abcdef)
+	if got := fn(0x89abcdef, 0x01234567); got != want {
+		t.Errorf("callback() = %#x, want %#x", got, want)
+	}
+}
+
+func TestNewCallbackInt64ResultWithStackArgs(t *testing.T) {
+	// On 386 all the arguments are passed on the stack, so this also checks
+	// that the copied arguments do not overlap the result of the callback.
+	const wantSum = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 + 16 + 17 + 18 + 19 + 20
+	imp := purego.NewCallback(func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20 int) int64 {
+		return int64(a1+a2+a3+a4+a5+a6+a7+a8+a9+a10+a11+a12+a13+a14+a15+a16+a17+a18+a19+a20)<<32 | 0x0badf00d
+	})
+	var fn func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20 int) int64
+	purego.RegisterFunc(&fn, imp)
+	const want = int64(wantSum)<<32 | 0x0badf00d
+	if got := fn(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20); got != want {
+		t.Errorf("callback() = %#x, want %#x", uint64(got), uint64(want))
+	}
+}
+
 func ExampleNewCallback() {
 	cb := purego.NewCallback(func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 int) int {
 		fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)

--- a/callback_test.go
+++ b/callback_test.go
@@ -187,14 +187,16 @@ func TestNewCallbackUint64Result(t *testing.T) {
 func TestNewCallbackInt64ResultWithStackArgs(t *testing.T) {
 	// On 386 all the arguments are passed on the stack, so this also checks
 	// that the copied arguments do not overlap the result of the callback.
-	const wantSum = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 + 16 + 17 + 18 + 19 + 20
-	imp := purego.NewCallback(func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20 int) int64 {
-		return int64(a1+a2+a3+a4+a5+a6+a7+a8+a9+a10+a11+a12+a13+a14+a15+a16+a17+a18+a19+a20)<<32 | 0x0badf00d
+	// The number of arguments is kept small enough for ppc64le, which only
+	// has maxArgs(15) slots in total, 8 of them in integer registers.
+	const wantSum = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12
+	imp := purego.NewCallback(func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 int) int64 {
+		return int64(a1+a2+a3+a4+a5+a6+a7+a8+a9+a10+a11+a12)<<32 | 0x0badf00d
 	})
-	var fn func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20 int) int64
+	var fn func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 int) int64
 	purego.RegisterFunc(&fn, imp)
 	const want = int64(wantSum)<<32 | 0x0badf00d
-	if got := fn(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20); got != want {
+	if got := fn(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12); got != want {
 		t.Errorf("callback() = %#x, want %#x", uint64(got), uint64(want))
 	}
 }

--- a/sys_unix_386.s
+++ b/sys_unix_386.s
@@ -29,9 +29,10 @@ TEXT callbackasm1(SB), NOSPLIT|NOFRAME, $0
 	//   0-15: saved callee-saved registers (BX, SI, DI, BP)
 	//   16-19: saved callback index
 	//   20-23: saved return address
-	//   24-35: callbackArgs struct (12 bytes)
-	//   36-291: copy of C arguments (256 bytes for 64 args, matching callbackMaxFrame)
-	// Total: 292 bytes, round up to 304 for alignment
+	//   24-47: callbackArgs struct (24 bytes: index, args, result[4],
+	//           matching Go's callbackArgs with room for 64-bit returns)
+	//   48-303: copy of C arguments (256 bytes for 64 args, matching callbackMaxFrame)
+	// Total: 304 bytes, already 16-byte aligned
 	SUBL $304, SP
 
 	// Save callee-saved registers
@@ -49,131 +50,131 @@ TEXT callbackasm1(SB), NOSPLIT|NOFRAME, $0
 	// Copy to our frame at 36(SP)
 	// Copy 64 arguments (256 bytes, matching callbackMaxFrame = 64 * ptrSize)
 	MOVL 308(SP), AX
-	MOVL AX, 36(SP)
-	MOVL 312(SP), AX
-	MOVL AX, 40(SP)
-	MOVL 316(SP), AX
-	MOVL AX, 44(SP)
-	MOVL 320(SP), AX
 	MOVL AX, 48(SP)
-	MOVL 324(SP), AX
+	MOVL 312(SP), AX
 	MOVL AX, 52(SP)
-	MOVL 328(SP), AX
+	MOVL 316(SP), AX
 	MOVL AX, 56(SP)
-	MOVL 332(SP), AX
+	MOVL 320(SP), AX
 	MOVL AX, 60(SP)
-	MOVL 336(SP), AX
+	MOVL 324(SP), AX
 	MOVL AX, 64(SP)
-	MOVL 340(SP), AX
+	MOVL 328(SP), AX
 	MOVL AX, 68(SP)
-	MOVL 344(SP), AX
+	MOVL 332(SP), AX
 	MOVL AX, 72(SP)
-	MOVL 348(SP), AX
+	MOVL 336(SP), AX
 	MOVL AX, 76(SP)
-	MOVL 352(SP), AX
+	MOVL 340(SP), AX
 	MOVL AX, 80(SP)
-	MOVL 356(SP), AX
+	MOVL 344(SP), AX
 	MOVL AX, 84(SP)
-	MOVL 360(SP), AX
+	MOVL 348(SP), AX
 	MOVL AX, 88(SP)
-	MOVL 364(SP), AX
+	MOVL 352(SP), AX
 	MOVL AX, 92(SP)
-	MOVL 368(SP), AX
+	MOVL 356(SP), AX
 	MOVL AX, 96(SP)
-	MOVL 372(SP), AX
+	MOVL 360(SP), AX
 	MOVL AX, 100(SP)
-	MOVL 376(SP), AX
+	MOVL 364(SP), AX
 	MOVL AX, 104(SP)
-	MOVL 380(SP), AX
+	MOVL 368(SP), AX
 	MOVL AX, 108(SP)
-	MOVL 384(SP), AX
+	MOVL 372(SP), AX
 	MOVL AX, 112(SP)
-	MOVL 388(SP), AX
+	MOVL 376(SP), AX
 	MOVL AX, 116(SP)
-	MOVL 392(SP), AX
+	MOVL 380(SP), AX
 	MOVL AX, 120(SP)
-	MOVL 396(SP), AX
+	MOVL 384(SP), AX
 	MOVL AX, 124(SP)
-	MOVL 400(SP), AX
+	MOVL 388(SP), AX
 	MOVL AX, 128(SP)
-	MOVL 404(SP), AX
+	MOVL 392(SP), AX
 	MOVL AX, 132(SP)
-	MOVL 408(SP), AX
+	MOVL 396(SP), AX
 	MOVL AX, 136(SP)
-	MOVL 412(SP), AX
+	MOVL 400(SP), AX
 	MOVL AX, 140(SP)
-	MOVL 416(SP), AX
+	MOVL 404(SP), AX
 	MOVL AX, 144(SP)
-	MOVL 420(SP), AX
+	MOVL 408(SP), AX
 	MOVL AX, 148(SP)
-	MOVL 424(SP), AX
+	MOVL 412(SP), AX
 	MOVL AX, 152(SP)
-	MOVL 428(SP), AX
+	MOVL 416(SP), AX
 	MOVL AX, 156(SP)
-	MOVL 432(SP), AX
+	MOVL 420(SP), AX
 	MOVL AX, 160(SP)
-	MOVL 436(SP), AX
+	MOVL 424(SP), AX
 	MOVL AX, 164(SP)
-	MOVL 440(SP), AX
+	MOVL 428(SP), AX
 	MOVL AX, 168(SP)
-	MOVL 444(SP), AX
+	MOVL 432(SP), AX
 	MOVL AX, 172(SP)
-	MOVL 448(SP), AX
+	MOVL 436(SP), AX
 	MOVL AX, 176(SP)
-	MOVL 452(SP), AX
+	MOVL 440(SP), AX
 	MOVL AX, 180(SP)
-	MOVL 456(SP), AX
+	MOVL 444(SP), AX
 	MOVL AX, 184(SP)
-	MOVL 460(SP), AX
+	MOVL 448(SP), AX
 	MOVL AX, 188(SP)
-	MOVL 464(SP), AX
+	MOVL 452(SP), AX
 	MOVL AX, 192(SP)
-	MOVL 468(SP), AX
+	MOVL 456(SP), AX
 	MOVL AX, 196(SP)
-	MOVL 472(SP), AX
+	MOVL 460(SP), AX
 	MOVL AX, 200(SP)
-	MOVL 476(SP), AX
+	MOVL 464(SP), AX
 	MOVL AX, 204(SP)
-	MOVL 480(SP), AX
+	MOVL 468(SP), AX
 	MOVL AX, 208(SP)
-	MOVL 484(SP), AX
+	MOVL 472(SP), AX
 	MOVL AX, 212(SP)
-	MOVL 488(SP), AX
+	MOVL 476(SP), AX
 	MOVL AX, 216(SP)
-	MOVL 492(SP), AX
+	MOVL 480(SP), AX
 	MOVL AX, 220(SP)
-	MOVL 496(SP), AX
+	MOVL 484(SP), AX
 	MOVL AX, 224(SP)
-	MOVL 500(SP), AX
+	MOVL 488(SP), AX
 	MOVL AX, 228(SP)
-	MOVL 504(SP), AX
+	MOVL 492(SP), AX
 	MOVL AX, 232(SP)
-	MOVL 508(SP), AX
+	MOVL 496(SP), AX
 	MOVL AX, 236(SP)
-	MOVL 512(SP), AX
+	MOVL 500(SP), AX
 	MOVL AX, 240(SP)
-	MOVL 516(SP), AX
+	MOVL 504(SP), AX
 	MOVL AX, 244(SP)
-	MOVL 520(SP), AX
+	MOVL 508(SP), AX
 	MOVL AX, 248(SP)
-	MOVL 524(SP), AX
+	MOVL 512(SP), AX
 	MOVL AX, 252(SP)
-	MOVL 528(SP), AX
+	MOVL 516(SP), AX
 	MOVL AX, 256(SP)
-	MOVL 532(SP), AX
+	MOVL 520(SP), AX
 	MOVL AX, 260(SP)
-	MOVL 536(SP), AX
+	MOVL 524(SP), AX
 	MOVL AX, 264(SP)
-	MOVL 540(SP), AX
+	MOVL 528(SP), AX
 	MOVL AX, 268(SP)
-	MOVL 544(SP), AX
+	MOVL 532(SP), AX
 	MOVL AX, 272(SP)
-	MOVL 548(SP), AX
+	MOVL 536(SP), AX
 	MOVL AX, 276(SP)
-	MOVL 552(SP), AX
+	MOVL 540(SP), AX
 	MOVL AX, 280(SP)
-	MOVL 556(SP), AX
+	MOVL 544(SP), AX
 	MOVL AX, 284(SP)
+	MOVL 548(SP), AX
+	MOVL AX, 288(SP)
+	MOVL 552(SP), AX
+	MOVL AX, 292(SP)
+	MOVL 556(SP), AX
+	MOVL AX, 296(SP)
 	MOVL 560(SP), AX
 	MOVL AX, 288(SP)
 
@@ -181,13 +182,18 @@ TEXT callbackasm1(SB), NOSPLIT|NOFRAME, $0
 	// struct callbackArgs {
 	//     index  uintptr  // offset 0
 	//     args   *byte    // offset 4
-	//     result uintptr  // offset 8
+	//     result uintptr  // offset 8 (4 words: result[0] + result[1] for
+	//                        64-bit returns + 2 spare, matching Go's
+	//                        callbackArgs.result [4]uintptr)
 	// }
 	MOVL 16(SP), AX // callback index
 	MOVL AX, 24(SP) // callbackArgs.index
-	LEAL 36(SP), AX // pointer to copied arguments
+	LEAL 48(SP), AX // pointer to copied arguments
 	MOVL AX, 28(SP) // callbackArgs.args
-	MOVL $0, 32(SP) // callbackArgs.result = 0
+	MOVL $0, 32(SP) // callbackArgs.result[0] = 0
+	MOVL $0, 36(SP) // callbackArgs.result[1] = 0
+	MOVL $0, 40(SP) // callbackArgs.result[2] = 0
+	MOVL $0, 44(SP) // callbackArgs.result[3] = 0
 
 	// Call crosscall2(fn, frame, 0, ctxt)
 	// crosscall2 expects arguments on stack:
@@ -209,8 +215,11 @@ TEXT callbackasm1(SB), NOSPLIT|NOFRAME, $0
 
 	ADDL $16, SP
 
-	// Get result from callbackArgs.result
+	// Get result from callbackArgs.result. i386 cdecl returns 64-bit
+	// values in EDX:EAX, so forward both halves written by
+	// setInt64Result/setUint64Result.
 	MOVL 32(SP), AX
+	MOVL 36(SP), DX
 
 	// Restore callee-saved registers
 	MOVL 0(SP), BX

--- a/sys_unix_386.s
+++ b/sys_unix_386.s
@@ -47,7 +47,7 @@ TEXT callbackasm1(SB), NOSPLIT|NOFRAME, $0
 
 	// Copy C arguments from original stack location to our frame
 	// Original args start at 304+4(SP) = 308(SP) (past our frame + original return addr)
-	// Copy to our frame at 36(SP)
+	// Copy to our frame at 48(SP)
 	// Copy 64 arguments (256 bytes, matching callbackMaxFrame = 64 * ptrSize)
 	MOVL 308(SP), AX
 	MOVL AX, 48(SP)
@@ -176,15 +176,14 @@ TEXT callbackasm1(SB), NOSPLIT|NOFRAME, $0
 	MOVL 556(SP), AX
 	MOVL AX, 296(SP)
 	MOVL 560(SP), AX
-	MOVL AX, 288(SP)
+	MOVL AX, 300(SP)
 
 	// Set up callbackArgs struct at 24(SP)
 	// struct callbackArgs {
-	//     index  uintptr  // offset 0
-	//     args   *byte    // offset 4
-	//     result uintptr  // offset 8 (4 words: result[0] + result[1] for
-	//                        64-bit returns + 2 spare, matching Go's
-	//                        callbackArgs.result [4]uintptr)
+	//     index  uintptr        // offset 0
+	//     args   unsafe.Pointer // offset 4
+	//     result [4]uintptr     // offset 8: result[0] and result[1] hold
+	//                            a 64-bit return, result[2:] are unused
 	// }
 	MOVL 16(SP), AX // callback index
 	MOVL AX, 24(SP) // callbackArgs.index


### PR DESCRIPTION
# What issue is this addressing?
Closes #524

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The 386 trampoline allocated only one result word and returned EAX alone, so int64/uint64 callbacks lost their upper half (cdecl wants EDX:EAX) and the args copy overlapped result[1..]. Widen the callbackArgs area to the full Go struct, shift the args copy by 12 bytes, and return both halves.
