### PR TITLE
purego: fix unclosed []interface{} notation in RegisterFunc doc

### DIFF
--- a/func.go
+++ b/func.go
@@ -73,7 +73,7 @@ func RegisterLibFunc(fptr any, handle uintptr, name string) {
 //	unsafe.Pointer, *T <=> void*
 //	[]T => void*
 //
-// There is a special case when the last argument of fptr is a variadic interface (or []interface}
+// There is a special case when the last argument of fptr is a variadic interface (or []any)
 // it will be expanded into a call to the C function as if it had the arguments in that slice.
 // This means that using arg ...any is like a cast to the function with the arguments inside arg.
 // This is not the same as C variadic.


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The RegisterFunc comment described the expandable variadic parameter as "(or []interface}" — the closing brace and parenthesis were missing.